### PR TITLE
Build on Travis CI and upload AppImage on each git push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt58-meta qt58base qt58scxml qt58xmlpatterns qt58svg zlib1g-dev
+    - sudo apt-get -y install qt58meta qt58base qt58scxml qt58xmlpatterns qt58svg zlib1g-dev
     - source /opt/qt58/bin/qt58-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt54base qt54xmlpatterns qt54svg zlib1g-dev
+    - sudo apt-get -y install qt54base qt54xmlpatterns qt58translations qt58tools qt54svg zlib1g-dev
     - source /opt/qt54/bin/qt54-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt58base qt58scxml qt58xmlpatterns qt58svg zlib1g-dev
+    - sudo apt-get -y install qt58base qt58scxml qt58xmlpatterns qt58svg qt58tools zlib1g-dev
     - source /opt/qt58/bin/qt58-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - cd build
   - cmake .. -DCMAKE_INSTALL_PREFIX=/usr
   - make -j4
-  - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/
+  - sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/
 
 after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+    - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+    - sudo apt-get update -qq
+    
+install: 
+    - sudo apt-get -y install qt58base qt58scxml qt58xmlpatterns qt58svg zlib1g-dev
+    - source /opt/qt58/bin/qt58-env.sh
+
+script:
+  - cd glabels
+  - mkdir build
+  - cd build
+  - cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+  - make -j4
+  - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/
+
+after_success:
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - curl --upload-file ./gLabels*.AppImage https://transfer.sh/gLabels-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ sudo: require
 dist: trusty
 
 before_install:
-    - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+    - sudo add-apt-repository ppa:beineri/opt-qt542-trusty -y
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt58meta qt58base qt58scxml qt58xmlpatterns qt58svg zlib1g-dev
-    - source /opt/qt58/bin/qt58-env.sh
+    - sudo apt-get -y install qt54base qt54xmlpatterns qt54svg zlib1g-dev
+    - source /opt/qt54/bin/qt54-env.sh
 
 script:
   - cd glabels

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ sudo: require
 dist: trusty
 
 before_install:
-    - sudo add-apt-repository ppa:beineri/opt-qt542-trusty -y
+    - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt54base qt54xmlpatterns qt54translations qt54tools qt54svg zlib1g-dev
-    - source /opt/qt54/bin/qt54-env.sh
+    - sudo apt-get -y install qt58base qt58xmlpatterns qt58translations qt58tools qt58svg zlib1g-dev
+    - source /opt/qt5*/bin/qt5*-env.sh
 
 script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ install:
     - source /opt/qt54/bin/qt54-env.sh
 
 script:
-  - cd glabels
   - mkdir build
   - cd build
   - cmake .. -DCMAKE_INSTALL_PREFIX=/usr

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt58base qt58scxml qt58xmlpatterns qt58svg qt58tools zlib1g-dev
+    - sudo apt-get -y install qt58-meta qt58base qt58scxml qt58xmlpatterns qt58svg zlib1g-dev
     - source /opt/qt58/bin/qt58-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - cd build
   - cmake .. -DCMAKE_INSTALL_PREFIX=/usr
   - make -j4
-  - sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/
+  - sudo make DESTDIR=appdir install ; sudo chown -R $USER appdir ; find appdir/
 
 after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt54base qt54xmlpatterns qt58translations qt58tools qt54svg zlib1g-dev
+    - sudo apt-get -y install qt54base qt54xmlpatterns qt54translations qt54tools qt54svg zlib1g-dev
     - source /opt/qt54/bin/qt54-env.sh
 
 script:


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build (see below for how to set up automatic uploading to your GitHub Releases page).

![screenshot from 2017-04-02 17-35-19](https://cloud.githubusercontent.com/assets/2480569/24588556/caf4aa16-17ca-11e7-89f2-18b2d02dbdb5.png)

For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Works for most Linux distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.

__Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. This way, they would be visible on the Releases page of your project. This is what I recommend. See https://docs.travis-ci.com/user/deployment/releases/. If you want to do this for continuous builds, also see https://github.com/probonopd/uploadtool.

If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.