### PR TITLE
Initial German GUI translation

### DIFF
--- a/translations/glabels_de_DE.ts
+++ b/translations/glabels_de_DE.ts
@@ -1,0 +1,2330 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE" sourcelanguage="en_US">
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../glabels/ui/AboutDialog.ui" line="23"/>
+        <source>About gLabels</source>
+        <translation>Info zu gLabels</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/AboutDialog.ui" line="92"/>
+        <source>&amp;License</source>
+        <translation>&amp;Lizenz</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/AboutDialog.ui" line="99"/>
+        <source>&amp;Website</source>
+        <translation>&amp;Webseite</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/AboutDialog.ui" line="119"/>
+        <source>&amp;Close</source>
+        <translation>&amp;Schließen</translation>
+    </message>
+</context>
+<context>
+    <name>Color name</name>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="40"/>
+        <source>Light Scarlet Red</source>
+        <translation>Helles Scharlachrot</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="41"/>
+        <source>Light Orange</source>
+        <translation>Helles Orange</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="42"/>
+        <source>Light Butter</source>
+        <translation>Helles Buttergelb</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="43"/>
+        <source>Light Chameleon</source>
+        <translation>Helles Chamäleon</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="44"/>
+        <source>Light Sky Blue</source>
+        <translation>Helles Himmelblau</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="45"/>
+        <source>Light Plum</source>
+        <translation>Helle Pflaume</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="46"/>
+        <source>Light Chocolate</source>
+        <translation>Helle Schokolade</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="47"/>
+        <source>Light Aluminum 1</source>
+        <translation>Helles Aluminium 1</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="48"/>
+        <source>Light Aluminum 2</source>
+        <translation>Helles Aluminium 2</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="50"/>
+        <source>Scarlet Red</source>
+        <translation>Scharlachrot</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="51"/>
+        <source>Orange</source>
+        <translation>Orange</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="52"/>
+        <source>Butter</source>
+        <translation>Buttergelb</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="53"/>
+        <source>Chameleon</source>
+        <translation>Chamäleon</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="54"/>
+        <source>Sky Blue</source>
+        <translation>Himmelblau</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="55"/>
+        <source>Plum</source>
+        <translation>Pflaume</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="56"/>
+        <source>Chocolate</source>
+        <translation>Schokolade</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="57"/>
+        <source>Aluminum 1</source>
+        <translation>Aluminium 1</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="58"/>
+        <source>Aluminum 2</source>
+        <translation>Aluminium 2</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="60"/>
+        <source>Dark Scarlet Red</source>
+        <translation>Dunkles Scharlachrot</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="61"/>
+        <source>Dark Orange</source>
+        <translation>Dunkles Orange</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="62"/>
+        <source>Dark Butter</source>
+        <translation>Dunkles Buttergelb</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="63"/>
+        <source>Dark Chameleon</source>
+        <translation>Dunkles Chamäleon</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="64"/>
+        <source>Dark Sky Blue</source>
+        <translation>Dunkles Himmelblau</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="65"/>
+        <source>Dark Plum</source>
+        <translation>Dunkle Pflaume</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="66"/>
+        <source>Dark Chocolate</source>
+        <translation>Dunkle Schokolade</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="67"/>
+        <source>Dark Aluminum 1</source>
+        <translation>Dunkles Aluminium 1</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="68"/>
+        <source>Dark Aluminum 2</source>
+        <translation>Dunkles Aluminium 2</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="70"/>
+        <source>Black</source>
+        <translation>Schwarz</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="71"/>
+        <source>Very Dark Gray</source>
+        <translation>Sehr dunkles Grau</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="72"/>
+        <source>Darker Gray</source>
+        <translation>Dunkleres Grau</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="73"/>
+        <source>Dark Gray</source>
+        <translation>Dunkles Grau</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="74"/>
+        <source>Medium Gray</source>
+        <translation>Mittleres Grau</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="75"/>
+        <source>Light Gray</source>
+        <translation>Helles Grau</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="76"/>
+        <source>Lighter Gray</source>
+        <translation>Helleres Grau</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="77"/>
+        <source>Very Light Gray</source>
+        <translation>Sehr helles Grau</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="78"/>
+        <source>White</source>
+        <translation>Weiß</translation>
+    </message>
+</context>
+<context>
+    <name>MergeView</name>
+    <message>
+        <location filename="../glabels/ui/MergeView.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formular</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/MergeView.ui" line="38"/>
+        <source>Source</source>
+        <translation>Quelle</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/MergeView.ui" line="46"/>
+        <source>Location</source>
+        <translation>Ort</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/MergeView.ui" line="53"/>
+        <source>Format:</source>
+        <translation>Format:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/MergeView.ui" line="60"/>
+        <source>Location:</source>
+        <translation>Ort:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/MergeView.ui" line="88"/>
+        <source>Records</source>
+        <translation>Datensätze</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/MergeView.ui" line="99"/>
+        <source>Select all</source>
+        <translation>Alles auswählen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/MergeView.ui" line="106"/>
+        <source>Unselect all</source>
+        <translation>Alles abwählen</translation>
+    </message>
+</context>
+<context>
+    <name>ObjectEditor</name>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="32"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="42"/>
+        <source>Text</source>
+        <translation>Text</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="48"/>
+        <source>Layout</source>
+        <translation>Anordnung</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="56"/>
+        <source>Alignment:</source>
+        <translation>Ausrichtung:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="222"/>
+        <source>Line spacing:</source>
+        <translation>Zeilenabstand:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="274"/>
+        <source>Font</source>
+        <translation>Schrift</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="288"/>
+        <source>Family:</source>
+        <translation>Familie:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="298"/>
+        <source>Size:</source>
+        <translation>Größe:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="305"/>
+        <source>Style:</source>
+        <translation>Stil:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="392"/>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="582"/>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="822"/>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="914"/>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1351"/>
+        <source>Color:</source>
+        <translation>Farbe:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="484"/>
+        <source>Editor</source>
+        <translation>Editor</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="534"/>
+        <source>Barcode</source>
+        <translation>Strichcode</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="553"/>
+        <source>Style</source>
+        <translation>Stil</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="561"/>
+        <source>Type:</source>
+        <translation>Typ:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="568"/>
+        <source>Show text</source>
+        <translation>Text anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="575"/>
+        <source>Checksum</source>
+        <translation>Prüfsumme</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="634"/>
+        <source>Barcode data</source>
+        <translation>Barcode-Daten</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="684"/>
+        <source>Image</source>
+        <translation>Bild</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="690"/>
+        <source>File</source>
+        <translation>Datei</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="713"/>
+        <source>None</source>
+        <translation>Keine</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="728"/>
+        <source>Select File...</source>
+        <translation>Datei auswählen …</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="741"/>
+        <source>or</source>
+        <translation>oder</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="755"/>
+        <source>Select Merge Field...</source>
+        <translation>Datenfeld auswählen …</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="784"/>
+        <source>Line/Fill</source>
+        <translation>Linie/Füllung</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="792"/>
+        <source>Line</source>
+        <translation>Linie</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="809"/>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1195"/>
+        <source>Width:</source>
+        <translation>Breite:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="900"/>
+        <source>Fill</source>
+        <translation>Füllung</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="968"/>
+        <source>Position/Size</source>
+        <translation>Position/Größe</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="974"/>
+        <source>Position</source>
+        <translation>Position</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="988"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1008"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1040"/>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1122"/>
+        <source>Size</source>
+        <translation>Größe</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1054"/>
+        <source>Length:</source>
+        <translation>Länge:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1074"/>
+        <source>Angle:</source>
+        <translation>Winkel:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1137"/>
+        <source>Original size:</source>
+        <translation>Originalgröße:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1144"/>
+        <source>Reset</source>
+        <translation>Zurücksetzen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1236"/>
+        <source>Lock aspect ratio</source>
+        <translation>Seitenverhältnis beibehalten</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1251"/>
+        <source>Height:</source>
+        <translation>Höhe:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1277"/>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1283"/>
+        <source>Shadow</source>
+        <translation>Schattierung</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1297"/>
+        <source>X offset:</source>
+        <translation>X-Position:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1324"/>
+        <source>Y offset:</source>
+        <translation>Y-Position:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1358"/>
+        <source>Opacity:</source>
+        <translation>Deckkraft:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/ObjectEditor.ui" line="1467"/>
+        <source>Object properties</source>
+        <translation>Objekteigenschaften</translation>
+    </message>
+</context>
+<context>
+    <name>PreferencesDialog</name>
+    <message>
+        <location filename="../glabels/ui/PreferencesDialog.ui" line="14"/>
+        <source>gLabels - Preferences</source>
+        <translation>gLabels – Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PreferencesDialog.ui" line="24"/>
+        <source>Locale</source>
+        <translation>Sprache</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PreferencesDialog.ui" line="43"/>
+        <source>Select locale specific behavior.</source>
+        <translation>Legen Sie das sprachspezifische Verhalten fest.</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PreferencesDialog.ui" line="50"/>
+        <source>Units</source>
+        <translation>Einheiten</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PreferencesDialog.ui" line="56"/>
+        <source>Points</source>
+        <translation>Punkte</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PreferencesDialog.ui" line="63"/>
+        <source>Centimeters</source>
+        <translation>Zentimeter</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PreferencesDialog.ui" line="70"/>
+        <source>Millimeters</source>
+        <translation>Millimeter</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PreferencesDialog.ui" line="77"/>
+        <source>Inches</source>
+        <translation>Zoll</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PreferencesDialog.ui" line="84"/>
+        <source>Picas</source>
+        <translation>Picas</translation>
+    </message>
+</context>
+<context>
+    <name>PrintView</name>
+    <message>
+        <location filename="../glabels/ui/PrintView.ui" line="20"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PrintView.ui" line="65"/>
+        <source>Page</source>
+        <translation>Seite</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PrintView.ui" line="79"/>
+        <source>of</source>
+        <translation>von</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PrintView.ui" line="86"/>
+        <source>nn</source>
+        <translation>nn</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PrintView.ui" line="143"/>
+        <source>Copies</source>
+        <translation>Kopien</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PrintView.ui" line="151"/>
+        <source>Copies:</source>
+        <translation>Kopien:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PrintView.ui" line="195"/>
+        <source>Start on position:</source>
+        <translation>Beginnen bei Position:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PrintView.ui" line="209"/>
+        <source>on 1st page</source>
+        <translation>auf der ersten Seite</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PrintView.ui" line="255"/>
+        <source>Print options</source>
+        <translation>Druckoptionen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PrintView.ui" line="263"/>
+        <source>print outlines</source>
+        <translation>Begrenzungen drucken</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PrintView.ui" line="270"/>
+        <source>print crop marks</source>
+        <translation>Schnittmarken drucken</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PrintView.ui" line="277"/>
+        <source>print in reverse (i.e. a mirror image)</source>
+        <translation>Spiegelbildlich drucken</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PrintView.ui" line="292"/>
+        <source>Print</source>
+        <translation>Drucken</translation>
+    </message>
+</context>
+<context>
+    <name>PropertiesView</name>
+    <message>
+        <location filename="../glabels/ui/PropertiesView.ui" line="26"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PropertiesView.ui" line="70"/>
+        <source>Product</source>
+        <translation>Produkt</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PropertiesView.ui" line="84"/>
+        <source>Vendor:</source>
+        <translation>Anbieter:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PropertiesView.ui" line="97"/>
+        <location filename="../glabels/ui/PropertiesView.ui" line="123"/>
+        <location filename="../glabels/ui/PropertiesView.ui" line="149"/>
+        <location filename="../glabels/ui/PropertiesView.ui" line="175"/>
+        <location filename="../glabels/ui/PropertiesView.ui" line="201"/>
+        <location filename="../glabels/ui/PropertiesView.ui" line="227"/>
+        <source>TextLabel</source>
+        <translation>TextLabel</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PropertiesView.ui" line="110"/>
+        <source>Part #:</source>
+        <translation>Bestellnummer:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PropertiesView.ui" line="136"/>
+        <source>Description:</source>
+        <translation>Beschreibung:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PropertiesView.ui" line="162"/>
+        <source>Page size:</source>
+        <translation>Seitengröße:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PropertiesView.ui" line="188"/>
+        <source>Label size:</source>
+        <translation>Etikettgröße:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PropertiesView.ui" line="214"/>
+        <source>Layout:</source>
+        <translation>Anordnung:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PropertiesView.ui" line="236"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select another product for this gLabels project.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wählen Sie ein anderes Produkt für dieses gLabels-Projekt.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PropertiesView.ui" line="242"/>
+        <source>Change product</source>
+        <translation>Produkt ändern</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PropertiesView.ui" line="268"/>
+        <source>Orientation</source>
+        <translation>Ausrichtung</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PropertiesView.ui" line="282"/>
+        <source>Select horizontal or vertical orientation.</source>
+        <translation>Wählen Sie die horizontale oder vertikale Ausrichtung.</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PropertiesView.ui" line="292"/>
+        <source>Horizontal orientation</source>
+        <translation>Horizontale Ausrichtung</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PropertiesView.ui" line="301"/>
+        <source>Vertical orientation</source>
+        <translation>Vertikale Ausrichtung</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/PropertiesView.ui" line="324"/>
+        <source>Similar Products</source>
+        <translation>Ähnliche Produkte</translation>
+    </message>
+</context>
+<context>
+    <name>SelectProductDialog</name>
+    <message>
+        <location filename="../glabels/ui/SelectProductDialog.ui" line="20"/>
+        <source>gLabels - Select Product</source>
+        <translation>gLabels - Produkt auswählen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/SelectProductDialog.ui" line="43"/>
+        <source>Search all</source>
+        <translation>Alle durchsuchen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/SelectProductDialog.ui" line="71"/>
+        <source>Search</source>
+        <translation>Suchen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/SelectProductDialog.ui" line="98"/>
+        <source>Filter by paper size</source>
+        <translation>Nach Papiergröße filtern</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/SelectProductDialog.ui" line="115"/>
+        <source>ISO sizes</source>
+        <translation>ISO-Größen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/SelectProductDialog.ui" line="122"/>
+        <source>US sizes</source>
+        <translation>US-Größen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/SelectProductDialog.ui" line="129"/>
+        <source>Other</source>
+        <translation>Andere</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/SelectProductDialog.ui" line="141"/>
+        <source>Filter by category</source>
+        <translation>Nach Kategorien filtern</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/SelectProductDialog.ui" line="150"/>
+        <source>All</source>
+        <translation>Alle</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/SelectProductDialog.ui" line="157"/>
+        <source>Selected</source>
+        <translation>Ausgewählt</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/SelectProductDialog.ui" line="213"/>
+        <source>Search entire product database.</source>
+        <translation>Die gesamte Produktdatenbank durchsuchen.</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/SelectProductDialog.ui" line="224"/>
+        <source>Recent</source>
+        <translation>Zuletzt verwendet</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/SelectProductDialog.ui" line="230"/>
+        <source>Select from recently used products.</source>
+        <translation>Aus zuletzt verwendeten Produkten auswählen.</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/SelectProductDialog.ui" line="287"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Abbrechen</translation>
+    </message>
+</context>
+<context>
+    <name>StartupView</name>
+    <message>
+        <location filename="../glabels/ui/StartupView.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/StartupView.ui" line="117"/>
+        <source>Welcome to gLabels.  Let&apos;s get started:</source>
+        <translation>Willkommen zu gLabels. Lassen Sie uns beginnen:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/StartupView.ui" line="139"/>
+        <source>New Project</source>
+        <translation>Neues Projekt</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/StartupView.ui" line="152"/>
+        <source>Create a new blank gLabels project</source>
+        <translation>Ein neues, leeres gLabels-Projekt erstellen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/StartupView.ui" line="171"/>
+        <source>Open Project</source>
+        <translation>Projekt öffnen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/StartupView.ui" line="184"/>
+        <source>Open an existing gLabels project</source>
+        <translation>Ein existierendes gLabels-Projekt öffnen</translation>
+    </message>
+</context>
+<context>
+    <name>TemplateDesignerApplyPage</name>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerApplyPage.ui" line="26"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerApplyPage.ui" line="35"/>
+        <source>You have completed the gLabels Product Template Designer.  If you wish to accept and save your product template, click &quot;Save.&quot;</source>
+        <translation>Das Erzeugen der Vorlage ist abgeschlossen. Falls Sie diese Vorlage akzeptieren und speichern wollen, klicken Sie auf »Speichern«</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerApplyPage.ui" line="45"/>
+        <source>Otherwise, you may click &quot;Cancel&quot; to abandon your design or &quot;Back&quot; to review or continue editing this product template.</source>
+        <translation>Anderenfalls klicken Sie auf »Abbrechen«, um die Vorlage zu verwerfen, oder auf »Zurück«, um die Vorlage erneut zu bearbeiten.</translation>
+    </message>
+</context>
+<context>
+    <name>TemplateDesignerCdPage</name>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerCdPage.ui" line="26"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerCdPage.ui" line="73"/>
+        <source>4. Clipping height:</source>
+        <translation>4. Innere Höhe:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerCdPage.ui" line="80"/>
+        <source>2. Inner radius:</source>
+        <translation>2.Innerer Radius:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerCdPage.ui" line="53"/>
+        <source>1. Outer radius:</source>
+        <translation>1. Äußerer Radius:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerCdPage.ui" line="144"/>
+        <source>5. Waste:</source>
+        <translation>5. Überstand:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerCdPage.ui" line="87"/>
+        <source>3. Clipping width:</source>
+        <translation>4. Innere Breite:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerCdPage.ui" line="46"/>
+        <source>6. Margin:</source>
+        <translation>6. Rand:</translation>
+    </message>
+</context>
+<context>
+    <name>TemplateDesignerEllipsePage</name>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerEllipsePage.ui" line="26"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerEllipsePage.ui" line="73"/>
+        <source>3. Waste:</source>
+        <translation>3. Überstand:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerEllipsePage.ui" line="59"/>
+        <source>2. Height:</source>
+        <translation>2. Höhe:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerEllipsePage.ui" line="66"/>
+        <source>1. Width:</source>
+        <translation>1. Breite:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerEllipsePage.ui" line="90"/>
+        <source>4. Margin:</source>
+        <translation>4. Rand:</translation>
+    </message>
+</context>
+<context>
+    <name>TemplateDesignerIntroPage</name>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerIntroPage.ui" line="26"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerIntroPage.ui" line="35"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This dialog will help you create a custom product template. Let&apos;s get started:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dieser Dialog hilft Ihnen beim Erstellen einer benutzerdefinierten Produktvorlage. Lassen Sie uns beginnen:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerIntroPage.ui" line="55"/>
+        <source>Copy/Edit Product</source>
+        <translation>Vorlage kopieren/bearbeiten</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerIntroPage.ui" line="58"/>
+        <source>Copy and edit an existing product template</source>
+        <translation>Eine existierende Vorlage kopieren und bearbeiten</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerIntroPage.ui" line="65"/>
+        <source>New Product</source>
+        <translation>Neue Vorlage</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerIntroPage.ui" line="68"/>
+        <source>Create a a new product template from scratch</source>
+        <translation>Eine Vorlage von Grund auf neu erstellen</translation>
+    </message>
+</context>
+<context>
+    <name>TemplateDesignerNLayoutsPage</name>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerNLayoutsPage.ui" line="26"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerNLayoutsPage.ui" line="40"/>
+        <source>A layout is a set of labels or cards that can be arranged in a simple grid.  Most products only need one layout, as in the first example below.  The second example illustrates when two layouts are needed.</source>
+        <translation>Ein Layout ist ein Satz von Etiketten oder Karten, die in einem einfachen Raster angeordnet sind. Die meisten Vorlagen verwenden nur ein Layout, wie im ersten Beispiel. Das zweite Beispiel zeigt die Verwendung zweier Layouts.</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerNLayoutsPage.ui" line="104"/>
+        <source>Products needing only one layout.</source>
+        <translation>Vorlagen benötigen nur ein Layout.</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerNLayoutsPage.ui" line="168"/>
+        <source>Products needing two layouts.</source>
+        <translation>Vorlagen benötigen zwei Layouts.</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerNLayoutsPage.ui" line="198"/>
+        <source>Note: if more than two layouts are required, the product template must be edited manually.</source>
+        <translation>Hinweis: Falls mehr als zwei Layouts erforderlich sein sollten, muss die Vorlage manuell nachbearbeitet werden.</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerNLayoutsPage.ui" line="213"/>
+        <source>One layout</source>
+        <translation>Ein Layout</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerNLayoutsPage.ui" line="223"/>
+        <source>Two layouts</source>
+        <translation>Zwei Layouts</translation>
+    </message>
+</context>
+<context>
+    <name>TemplateDesignerNamePage</name>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerNamePage.ui" line="26"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerNamePage.ui" line="70"/>
+        <source>Brand:</source>
+        <translation>Marke:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerNamePage.ui" line="117"/>
+        <source>(e.g. Avery, Acme, ...)</source>
+        <translation>(z.B.. Avery, Acme, …)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerNamePage.ui" line="77"/>
+        <source>Part #:</source>
+        <translation>Bestellnummer:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerNamePage.ui" line="107"/>
+        <source>(e.g. 8163A)</source>
+        <translation>(z.B. 8163A)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerNamePage.ui" line="97"/>
+        <source>Description:</source>
+        <translation>Beschreibung:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerNamePage.ui" line="63"/>
+        <source>(e.g. &quot;Mailing Labels,&quot; &quot;Business Cards,&quot; ...)</source>
+        <translation>(z.B. »Adressaufkleber«, »Visitenkarten« …)</translation>
+    </message>
+</context>
+<context>
+    <name>TemplateDesignerOneLayoutPage</name>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerOneLayoutPage.ui" line="26"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerOneLayoutPage.ui" line="37"/>
+        <source>Number across (nx):</source>
+        <translation>Anzahl horizontal (nx):</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerOneLayoutPage.ui" line="51"/>
+        <source>Number down (ny):</source>
+        <translation>Anzahl vertikal (nx):</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerOneLayoutPage.ui" line="65"/>
+        <source>Distance from left edge (x0):</source>
+        <translation>Abstand vom linken Rand (x0):</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerOneLayoutPage.ui" line="82"/>
+        <source>Distance from top edge (y0);</source>
+        <translation>Abstand vom oberen Rand (y0):</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerOneLayoutPage.ui" line="99"/>
+        <source>Horizontal pitch (dx):</source>
+        <translation>Horizontaler Abstand (dx):</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerOneLayoutPage.ui" line="116"/>
+        <source>Vertical pitch (dy):</source>
+        <translation>Vertikaler Abstand (dy):</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerOneLayoutPage.ui" line="161"/>
+        <source>Print test sheet</source>
+        <translation>Testseite drucken</translation>
+    </message>
+</context>
+<context>
+    <name>TemplateDesignerPageSizePage</name>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerPageSizePage.ui" line="26"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerPageSizePage.ui" line="34"/>
+        <source>Page size:</source>
+        <translation>Seitengröße:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerPageSizePage.ui" line="41"/>
+        <source>Width:</source>
+        <translation>Breite:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerPageSizePage.ui" line="58"/>
+        <source>Height:</source>
+        <translation>Höhe:</translation>
+    </message>
+</context>
+<context>
+    <name>TemplateDesignerRectPage</name>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerRectPage.ui" line="26"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerRectPage.ui" line="83"/>
+        <source>1. Width:</source>
+        <translation>1. Breite:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerRectPage.ui" line="36"/>
+        <source>2. Height:</source>
+        <translation>2. Höhe:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerRectPage.ui" line="107"/>
+        <source>3. Corner radius</source>
+        <translation>3. Radius der Ecken</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerRectPage.ui" line="100"/>
+        <source>4. Horizontal waste:</source>
+        <translation>4. Horizontaler Überstand:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerRectPage.ui" line="131"/>
+        <source>5. Vertical waste:</source>
+        <translation>4. Vertikaler Überstand:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerRectPage.ui" line="114"/>
+        <source>6. Margin:</source>
+        <translation>6. Rand:</translation>
+    </message>
+</context>
+<context>
+    <name>TemplateDesignerRoundPage</name>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerRoundPage.ui" line="26"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerRoundPage.ui" line="93"/>
+        <source>2. Waste:</source>
+        <translation>2. Überstand:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerRoundPage.ui" line="86"/>
+        <source>1. Radius:</source>
+        <translation>1. Radius:</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerRoundPage.ui" line="79"/>
+        <source>3. Margin</source>
+        <translation>3. Rand</translation>
+    </message>
+</context>
+<context>
+    <name>TemplateDesignerShapePage</name>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerShapePage.ui" line="26"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerShapePage.ui" line="34"/>
+        <source>Rectangular or square (can have rounded corners)</source>
+        <translation>Rechteckig oder quadratisch (auch mit abgerundeten Ecken)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerShapePage.ui" line="44"/>
+        <source>Round</source>
+        <translation>Rund</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerShapePage.ui" line="51"/>
+        <source>Elliptical</source>
+        <translation>Elliptisch</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerShapePage.ui" line="58"/>
+        <source>CD/DVD (including credit card CDs)</source>
+        <translation>CD/DVD (einschließlich Kreditkarten-CDs)</translation>
+    </message>
+</context>
+<context>
+    <name>TemplateDesignerTwoLayoutPage</name>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerTwoLayoutPage.ui" line="26"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerTwoLayoutPage.ui" line="37"/>
+        <source>Distance from left edge (x0):</source>
+        <translation>Abstand vom linken Rand (x0):</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerTwoLayoutPage.ui" line="57"/>
+        <source>Number down (ny):</source>
+        <translation>Anzahl vertikal (nx):</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerTwoLayoutPage.ui" line="74"/>
+        <source>Distance from top edge (y0);</source>
+        <translation>Abstand vom oberen Rand (y0):</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerTwoLayoutPage.ui" line="94"/>
+        <source>Number across (nx):</source>
+        <translation>Anzahl horizontal (nx):</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerTwoLayoutPage.ui" line="101"/>
+        <source>Horizontal pitch (dx):</source>
+        <translation>Horizontaler Abstand (dx):</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerTwoLayoutPage.ui" line="118"/>
+        <source>Vertical pitch (dy):</source>
+        <translation>Vertikaler Abstand (dy):</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ui/TemplateDesignerTwoLayoutPage.ui" line="199"/>
+        <source>Print test sheet</source>
+        <translation>Testseite drucken</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::AboutDialog</name>
+    <message>
+        <location filename="../glabels/AboutDialog.cpp" line="41"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../glabels/AboutDialog.cpp" line="43"/>
+        <source>A program to create labels and business cards.</source>
+        <translation>Ein Programm zum Entwerfen von Etiketten und Visitenkarten.</translation>
+    </message>
+    <message>
+        <location filename="../glabels/AboutDialog.cpp" line="48"/>
+        <source>gLabels is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</source>
+        <translation>gLabels ist freie Software; Sie können es unter den Bedingungen der GNU General Public License weiterverteilen und/oder ändern, veröffentlicht von der Free Software Foundation, entweder in Version 3 der Lizenz oder (optional) in jeder späteren Version.</translation>
+    </message>
+    <message>
+        <location filename="../glabels/AboutDialog.cpp" line="54"/>
+        <source>gLabels is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.</source>
+        <translation>gLabels wurde mit dem Ziel veröffentlicht, dass Sie es nützlich finden, jedoch OHNE JEGLICHE GARANTIE, sogar ohne eine implizite Garantie der MARKTREIFE oder der EIGNUNG FÜR EINEN SPEZIELLEN ZWECK. Schauen Sie für weitere Informationen bitte in der »GNU General Public License« (GNU GPL) nach.</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::ColorPaletteDialog</name>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="152"/>
+        <source>Custom color...</source>
+        <translation>Benutzerdefinierte Farbe …</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="162"/>
+        <source>Merge key...</source>
+        <translation>Datenfeld auswählen …</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="256"/>
+        <source>Custom Color</source>
+        <translation>Benutzerdefinierte Farbe</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ColorPaletteDialog.cpp" line="292"/>
+        <source>Custom color #%1</source>
+        <translation>Benutzerdefinierte Farbe Nr. %1</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::File</name>
+    <message>
+        <location filename="../glabels/File.cpp" line="104"/>
+        <source>gLabels - Open Project</source>
+        <translation>gLabels - Projekt öffnen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/File.cpp" line="106"/>
+        <location filename="../glabels/File.cpp" line="187"/>
+        <source>glabels files (*.glabels);;All files (*)</source>
+        <translation>glabels-Dateien (*.glabels);;Alle Dateien (*)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/File.cpp" line="133"/>
+        <source>Unable to open &quot;</source>
+        <translation>Folgendes konnte nicht geöffnet werden: »</translation>
+    </message>
+    <message>
+        <location filename="../glabels/File.cpp" line="133"/>
+        <source>&quot;.</source>
+        <translation>«.</translation>
+    </message>
+    <message>
+        <location filename="../glabels/File.cpp" line="185"/>
+        <source>gLabels - Save Project As</source>
+        <translation>gLabels - Projekt speichern unter</translation>
+    </message>
+    <message>
+        <location filename="../glabels/File.cpp" line="198"/>
+        <source>Save Label As</source>
+        <translation>Etikett speichern unter</translation>
+    </message>
+    <message>
+        <location filename="../glabels/File.cpp" line="200"/>
+        <source>%1 already exists.</source>
+        <translation>%1 existiert bereits.</translation>
+    </message>
+    <message>
+        <location filename="../glabels/File.cpp" line="201"/>
+        <source>Do you want to replace it?</source>
+        <translation>Wollen Sie es ersetzen?</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::LabelEditor</name>
+    <message>
+        <location filename="../glabels/LabelEditor.cpp" line="652"/>
+        <location filename="../glabels/LabelEditor.cpp" line="952"/>
+        <location filename="../glabels/LabelEditor.cpp" line="957"/>
+        <location filename="../glabels/LabelEditor.cpp" line="962"/>
+        <location filename="../glabels/LabelEditor.cpp" line="967"/>
+        <source>Move</source>
+        <translation>Verschieben</translation>
+    </message>
+    <message>
+        <location filename="../glabels/LabelEditor.cpp" line="972"/>
+        <source>Delete</source>
+        <translation>Löschen</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::MainWindow</name>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="83"/>
+        <source>Welcome</source>
+        <translation>Willkommen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="89"/>
+        <source>Home</source>
+        <translation>Home</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="95"/>
+        <source>Properties</source>
+        <translation>Eigenschaften</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="101"/>
+        <source>Merge</source>
+        <translation>Seriendokument</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="107"/>
+        <source>Print</source>
+        <translation>Drucken</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="225"/>
+        <source>&amp;New...</source>
+        <translation>&amp;Neu …</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="228"/>
+        <source>Create a new gLabels project</source>
+        <translation>Ein neues gLabels-Projekt erstellen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="231"/>
+        <source>&amp;Open...</source>
+        <translation>Ö&amp;ffnen …</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="234"/>
+        <source>Open an existing gLabels project</source>
+        <translation>Ein existierendes gLabels-Projekt öffnen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="237"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Speichern</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="240"/>
+        <source>Save current gLabels project</source>
+        <translation>Aktuelles gLabels-Projekt speichern</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="243"/>
+        <source>Save &amp;As...</source>
+        <translation>Speichern &amp;unter …</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="246"/>
+        <source>Save current gLabels project to a different name</source>
+        <translation>Aktuelles gLabels-Projekt unter einem anderen Namen speichern</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="249"/>
+        <source>Product Template &amp;Designer...</source>
+        <translation>Vorlagen-&amp;Designer …</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="250"/>
+        <source>Create custom templates</source>
+        <translation>Benutzerdefinierte Vorlagen erstellen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="253"/>
+        <source>&amp;Close</source>
+        <translation>S&amp;chließen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="256"/>
+        <source>Close the current window</source>
+        <translation>Das aktuelle Fenster schließen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="259"/>
+        <source>E&amp;xit</source>
+        <translation>&amp;Beenden</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="262"/>
+        <source>Exit glabels</source>
+        <translation>gLabels beenden</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="267"/>
+        <location filename="../glabels/MainWindow.cpp" line="270"/>
+        <source>Undo</source>
+        <translation>Rückgängig</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="273"/>
+        <location filename="../glabels/MainWindow.cpp" line="276"/>
+        <source>Redo</source>
+        <translation>Wiederholen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="279"/>
+        <location filename="../glabels/MainWindow.cpp" line="487"/>
+        <location filename="../glabels/MainWindow.cpp" line="1089"/>
+        <source>Cut</source>
+        <translation>Ausschneiden</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="282"/>
+        <location filename="../glabels/MainWindow.cpp" line="489"/>
+        <source>Cut the selection</source>
+        <translation>Die Auswahl ausschneiden</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="285"/>
+        <location filename="../glabels/MainWindow.cpp" line="492"/>
+        <source>&amp;Copy</source>
+        <translation>&amp;Kopieren</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="288"/>
+        <location filename="../glabels/MainWindow.cpp" line="494"/>
+        <source>Copy the selection</source>
+        <translation>Die Auswahl kopieren</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="291"/>
+        <location filename="../glabels/MainWindow.cpp" line="497"/>
+        <source>&amp;Paste</source>
+        <translation>Ein&amp;fügen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="294"/>
+        <location filename="../glabels/MainWindow.cpp" line="499"/>
+        <source>Paste the clipboard</source>
+        <translation>Den Inhalt der Zwischenablage einfügen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="297"/>
+        <location filename="../glabels/MainWindow.cpp" line="502"/>
+        <source>&amp;Delete</source>
+        <translation>&amp;Löschen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="300"/>
+        <location filename="../glabels/MainWindow.cpp" line="504"/>
+        <source>Delete the selected objects</source>
+        <translation>Die ausgewählten Objekte löschen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="303"/>
+        <source>Select &amp;All</source>
+        <translation>&amp;Alles auswählen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="306"/>
+        <source>Select all objects</source>
+        <translation>Alle Objekte auswählen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="309"/>
+        <source>Un-select All</source>
+        <translation>Alles abwählen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="311"/>
+        <source>Remove all selections</source>
+        <translation>Alle Auswahlen aufheben</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="314"/>
+        <source>Preferences</source>
+        <translation>Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="317"/>
+        <source>Configure the application</source>
+        <translation>Die Anwendung einrichten</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="322"/>
+        <source>File</source>
+        <translation>Datei</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="324"/>
+        <source>Change visibility of file toolbar in current window</source>
+        <translation>Die Sichtbarkeit der Werkzeugleiste im aktuellen Fenster ändern</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="327"/>
+        <source>Editor</source>
+        <translation>Editor</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="329"/>
+        <source>Change visibility of editor toolbar in current window</source>
+        <translation>Die Sichtbarkeit des Editors im aktuellen Fenster ändern</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="333"/>
+        <source>Grid</source>
+        <translation>Gitter</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="335"/>
+        <source>Change visibility of the grid in current window</source>
+        <translation>Die Sichtbarkeit des Gitters im aktuellen Fenster ändern</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="338"/>
+        <source>Markup</source>
+        <translation>Markierungen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="340"/>
+        <source>Change visibility of markup lines in current window</source>
+        <translation>Die Sichtbarkeit von Markierungslinien im aktuellen Fenster ändern</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="343"/>
+        <source>Zoom &amp;In</source>
+        <translation>Ver&amp;größern</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="346"/>
+        <source>Increase magnification</source>
+        <translation>Vergrößerungsstufe erhöhen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="349"/>
+        <source>Zoom &amp;Out</source>
+        <translation>Ver&amp;kleinern</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="352"/>
+        <source>Decrease magnification</source>
+        <translation>Vergrößerungsstufe verringern</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="355"/>
+        <source>Zoom &amp;1 to 1</source>
+        <translation>Vergrößerung &amp;1:1</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="357"/>
+        <source>Restore scale to 100%</source>
+        <translation>Maßstab auf 100% wiederherstellen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="360"/>
+        <source>Zoom to &amp;Fit</source>
+        <translation>Ein&amp;passen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="362"/>
+        <source>Set scale to fit window</source>
+        <translation>In Fenster einpassen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="367"/>
+        <source>Select Mode</source>
+        <translation>Modus auswählen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="369"/>
+        <source>Select, move and modify objects</source>
+        <translation>Objekte auswählen, bewegen, ändern</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="372"/>
+        <source>Text</source>
+        <translation>Text</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="374"/>
+        <source>Create text object</source>
+        <translation>Ein Textobjekt erstellen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="377"/>
+        <source>Box</source>
+        <translation>Rechteck</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="379"/>
+        <source>Create box object</source>
+        <translation>Ein Rechteck-Objekt erstellen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="382"/>
+        <source>Line</source>
+        <translation>Linie</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="384"/>
+        <source>Create line object</source>
+        <translation>Ein Linienobjekt erstellen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="387"/>
+        <source>Ellipse</source>
+        <translation>Ellipse</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="389"/>
+        <source>Create ellipse/circle object</source>
+        <translation>Ein Ein Ellipsen- oder Kreisobjekt erstellen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="392"/>
+        <source>Image</source>
+        <translation>Bild</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="394"/>
+        <source>Create image object</source>
+        <translation>Ein Bildobjekt erstellen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="397"/>
+        <source>Barcode</source>
+        <translation>Strichcode</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="399"/>
+        <source>Create barcode object</source>
+        <translation>Ein Barcode-Objekt erstellen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="402"/>
+        <location filename="../glabels/MainWindow.cpp" line="1298"/>
+        <source>Bring To Front</source>
+        <translation>Ganz nach vorn</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="404"/>
+        <source>Raise selection to top</source>
+        <translation>Auswahl ganz nach vorn bringen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="407"/>
+        <location filename="../glabels/MainWindow.cpp" line="1308"/>
+        <source>Send To Back</source>
+        <translation>Ganz nach hinten</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="409"/>
+        <source>Lower selection to bottom</source>
+        <translation>Auswahl ganz nach hinten bringen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="412"/>
+        <location filename="../glabels/MainWindow.cpp" line="1318"/>
+        <source>Rotate Left</source>
+        <translation>Links drehen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="414"/>
+        <source>Rotate object(s) 90 degrees counter-clockwise</source>
+        <translation>Objekt um 90 Grad gegen den Uhrzeigersinn drehen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="417"/>
+        <location filename="../glabels/MainWindow.cpp" line="1328"/>
+        <source>Rotate Right</source>
+        <translation>Rechts drehen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="419"/>
+        <source>Rotate object(s) 90 degrees clockwise</source>
+        <translation>Objekt um 90 Grad im Uhrzeigersinn drehen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="422"/>
+        <location filename="../glabels/MainWindow.cpp" line="1338"/>
+        <source>Flip Horizontally</source>
+        <translation>Horizontal spiegeln</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="424"/>
+        <source>Flip object(s) horizontally</source>
+        <translation>Objekt(e) horizontal spiegeln</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="427"/>
+        <location filename="../glabels/MainWindow.cpp" line="1348"/>
+        <source>Flip Vertically</source>
+        <translation>Vertikal spiegeln</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="429"/>
+        <source>Flip object(s) vertically</source>
+        <translation>Objekt(e) vertikal spiegeln</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="432"/>
+        <location filename="../glabels/MainWindow.cpp" line="1358"/>
+        <source>Align Left</source>
+        <translation>Links ausrichten</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="434"/>
+        <source>Align objects to left edges</source>
+        <translation>Objekte am linken Rand anordnen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="437"/>
+        <location filename="../glabels/MainWindow.cpp" line="1368"/>
+        <source>Align Center</source>
+        <translation>Zentral ausrichten</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="439"/>
+        <source>Align objects to horizontal centers</source>
+        <translation>Objekte an der horizontalen Mitte anordnen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="442"/>
+        <location filename="../glabels/MainWindow.cpp" line="1378"/>
+        <source>Align Right</source>
+        <translation>Rechts ausrichten</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="444"/>
+        <source>Align objects to right edges</source>
+        <translation>Objekte am rechten Rand anordnen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="447"/>
+        <location filename="../glabels/MainWindow.cpp" line="1388"/>
+        <source>Align Top</source>
+        <translation>Oben ausrichten</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="449"/>
+        <source>Align objects to top edges</source>
+        <translation>Objekte am oberen Rand anordnen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="452"/>
+        <location filename="../glabels/MainWindow.cpp" line="1398"/>
+        <source>Align Middle</source>
+        <translation>Mittig ausrichten</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="454"/>
+        <source>Align objects to vertical centers</source>
+        <translation>Objekte an der vertikalen Mitte anordnen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="457"/>
+        <location filename="../glabels/MainWindow.cpp" line="1408"/>
+        <source>Align Bottom</source>
+        <translation>Unten ausrichten</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="459"/>
+        <source>Align objects to bottom edges</source>
+        <translation>Objekte am unteren Rand anordnen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="462"/>
+        <location filename="../glabels/MainWindow.cpp" line="1418"/>
+        <source>Center Horizontally</source>
+        <translation>Horizontal zentrieren</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="464"/>
+        <source>Horizontally center objects in label</source>
+        <translation>Objekte auf dem Etikett horizontal zentrieren</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="467"/>
+        <location filename="../glabels/MainWindow.cpp" line="1428"/>
+        <source>Center Vertically</source>
+        <translation>Vertikal zentrieren</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="469"/>
+        <source>Vertically center objects in label</source>
+        <translation>Objekte auf dem Etikett vertikal zentrieren</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="474"/>
+        <source>&amp;Contents...</source>
+        <translation>&amp;Inhalt …</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="477"/>
+        <source>Open gLabels manual</source>
+        <translation>Das gLabels-Handbuch öffnen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="480"/>
+        <source>&amp;About...</source>
+        <translation>In&amp;fo …</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="482"/>
+        <source>About gLabels</source>
+        <translation>Info zu gLabels</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="514"/>
+        <location filename="../glabels/MainWindow.cpp" line="622"/>
+        <source>&amp;File</source>
+        <translation>&amp;Datei</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="525"/>
+        <source>&amp;Edit</source>
+        <translation>&amp;Bearbeiten</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="539"/>
+        <source>&amp;View</source>
+        <translation>&amp;Ansicht</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="540"/>
+        <source>Toolbars</source>
+        <translation>Werkzeugleisten</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="552"/>
+        <source>&amp;Objects</source>
+        <translation>&amp;Objekte</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="554"/>
+        <source>&amp;Create</source>
+        <translation>Er&amp;zeugen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="562"/>
+        <location filename="../glabels/MainWindow.cpp" line="587"/>
+        <source>&amp;Order</source>
+        <translation>&amp;Anordnung</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="565"/>
+        <location filename="../glabels/MainWindow.cpp" line="590"/>
+        <source>&amp;Rotate/Flip</source>
+        <translation>D&amp;rehen/Spiegeln</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="570"/>
+        <location filename="../glabels/MainWindow.cpp" line="595"/>
+        <source>&amp;Alignment</source>
+        <translation>&amp;Ausrichtung</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="578"/>
+        <location filename="../glabels/MainWindow.cpp" line="603"/>
+        <source>Center</source>
+        <translation>Mitte</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="582"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Hilfe</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="631"/>
+        <source>&amp;Editor</source>
+        <translation>&amp;Editor</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="875"/>
+        <source>(modified)</source>
+        <translation>(geändert)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="938"/>
+        <source>Save changes to project &quot;%1&quot; before closing?</source>
+        <translation>Änderungen am Dokument »%1« vor dem Schließen speichern?</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="939"/>
+        <source>Your changes will be lost if you don&apos;t save them.</source>
+        <translation>Nicht gespeicherte Änderungen gehen verloren, wenn Sie nicht speichern.</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="942"/>
+        <source>Save project?</source>
+        <translation>Projekt speichern?</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="1109"/>
+        <source>Paste</source>
+        <translation>Einfügen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="1119"/>
+        <source>Delete</source>
+        <translation>Löschen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="1238"/>
+        <source>Create Text</source>
+        <translation>Textobjekt erzeugen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="1248"/>
+        <source>Create Box</source>
+        <translation>Rechteck-Objekt erzeugen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="1258"/>
+        <source>Create Line</source>
+        <translation>Linienobjekt erzeugen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="1268"/>
+        <source>Create Ellipse</source>
+        <translation>Ellipse erzeugen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="1278"/>
+        <source>Create Image</source>
+        <translation>Bild erzeugen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MainWindow.cpp" line="1288"/>
+        <source>Create Barcode</source>
+        <translation>Strichcode erzeugen</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::MergeView</name>
+    <message>
+        <location filename="../glabels/MergeView.cpp" line="41"/>
+        <source>Merge</source>
+        <translation>Seriendokument</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MergeView.cpp" line="192"/>
+        <source>Select merge file</source>
+        <translation>Datenquelle auswählen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/MergeView.cpp" line="194"/>
+        <source>All files (*)</source>
+        <translation>Alle Dateien (*)</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::ObjectEditor</name>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="194"/>
+        <source>Original size</source>
+        <translation>Originalgröße</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="352"/>
+        <source>Box object properties</source>
+        <translation>Eigenschaften des Rechteck-Objekts</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="373"/>
+        <source>Ellipse object properties</source>
+        <translation>Eigenschaften des Ellipsenobjekts</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="394"/>
+        <source>Image object properties</source>
+        <translation>Eigenschaften des Bildobjekts</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="414"/>
+        <source>Line object properties</source>
+        <translation>Eigenschaften des Linienobjekts</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="435"/>
+        <source>Text object properties</source>
+        <translation>Eigenschaften des Textobjekts</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="454"/>
+        <source>Barcode object properties</source>
+        <translation>Eigenschaften des Strichcode-Objekts</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="539"/>
+        <source>Line</source>
+        <translation>Linie</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="555"/>
+        <source>Fill</source>
+        <translation>Füllung</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="578"/>
+        <source>Image files (*.png *.jpg *.jpeg *.gif *.bmp *.pbm *.pgm *.ppm *.xbm *.xpm *.svg)</source>
+        <translation>Bilddateien (*.png *.jpg *.jpeg *.gif *.bmp *.pbm *.pgm *.ppm *.xbm *.xpm *.svg)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="579"/>
+        <source>All files (*)</source>
+        <translation>Alle Dateien (*)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="580"/>
+        <source>PNG - Portable Network Graphics (*.png)</source>
+        <translation>PNG - Portable Network Graphics (*.png)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="581"/>
+        <source>BMP - Windows Bitmap (*.bmp)</source>
+        <translation>BMP - Windows Bitmap (*.bmp)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="582"/>
+        <source>GIF - Graphics Interchange Format (*.gif)</source>
+        <translation>GIF - Graphics Interchange Format (*.gif)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="583"/>
+        <source>JPEG - Joint Photographic Experts Group (*.jpg *.jpeg)</source>
+        <translation>JPEG - Joint Photographic Experts Group (*.jpg *.jpeg)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="584"/>
+        <source>PBM - Portable Bitmap (*.pbm)</source>
+        <translation>PBM - Portable Bitmap (*.pbm)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="585"/>
+        <source>PGM - Portable Graymap (*.pgm)</source>
+        <translation>PGM - Portable Graymap (*.pgm)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="586"/>
+        <source>PPM - Portable Pixmap (*.ppm)</source>
+        <translation>PPM - Portable Pixmap (*.ppm)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="587"/>
+        <source>SVG - Scalable Vector Graphics (*.svg)</source>
+        <translation>SVG - Scalable Vector Graphics (*.svg)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="588"/>
+        <source>XBM - X11 Bitmap (*.xbm)</source>
+        <translation>XBM - X11 Bitmap (*.xbm)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="589"/>
+        <source>XPM - X11 Pixmap (*.xpm)</source>
+        <translation>XPM - X11 Pixmap (*.xpm)</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="593"/>
+        <source>gLabels - Select image file</source>
+        <translation>gLabels - Bilddatei wählen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="598"/>
+        <location filename="../glabels/ObjectEditor.cpp" line="610"/>
+        <source>Set image</source>
+        <translation>Bild festlegen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="621"/>
+        <source>Move</source>
+        <translation>Verschieben</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="639"/>
+        <location filename="../glabels/ObjectEditor.cpp" line="673"/>
+        <source>Size</source>
+        <translation>Größe</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="692"/>
+        <source>Text</source>
+        <translation>Text</translation>
+    </message>
+    <message>
+        <location filename="../glabels/ObjectEditor.cpp" line="766"/>
+        <source>Shadow</source>
+        <translation>Schattierung</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::PrintView</name>
+    <message>
+        <location filename="../glabels/PrintView.cpp" line="38"/>
+        <source>Print</source>
+        <translation>Drucken</translation>
+    </message>
+    <message>
+        <location filename="../glabels/PrintView.cpp" line="85"/>
+        <source>(Will print a total of %1 items on %2 pages.)</source>
+        <translation>(Es werden insgesamt %1 Exemplare auf %2 Seiten gedruckt.)</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::PropertiesView</name>
+    <message>
+        <location filename="../glabels/PropertiesView.cpp" line="44"/>
+        <source>Properties</source>
+        <translation>Eigenschaften</translation>
+    </message>
+    <message>
+        <location filename="../glabels/PropertiesView.cpp" line="191"/>
+        <source>Product Rotate</source>
+        <translation>Produkt drehen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/PropertiesView.cpp" line="220"/>
+        <source>Change Product</source>
+        <translation>Produkt wechseln</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::SimplePreview</name>
+    <message>
+        <location filename="../glabels/SimplePreview.cpp" line="238"/>
+        <source>Up</source>
+        <translation>Nach oben</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::TemplateDesigner</name>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="111"/>
+        <source>Product Template Designer</source>
+        <translation>Vorlagendesigner</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="455"/>
+        <source>Copy</source>
+        <translation>Kopieren</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::TemplateDesignerApplyPage</name>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="1386"/>
+        <location filename="../glabels/TemplateDesigner.cpp" line="1413"/>
+        <source>Save Product Template</source>
+        <translation>Vorlage speichern</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="1387"/>
+        <source>Click &quot;Save&quot; to save your custom product template!</source>
+        <translation>Klicken Sie auf »Speichern«, um Ihre benutzerdefinierte Vorlage zu speichern!</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="1415"/>
+        <source>User product template (%1 %2) already exists.</source>
+        <translation>Die benutzerdefinierte Vorlage (%1 %2) existiert bereits.</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="1416"/>
+        <source>Do you want to replace it?</source>
+        <translation>Wollen Sie sie ersetzen?</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::TemplateDesignerCdPage</name>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="981"/>
+        <source>Product Size</source>
+        <translation>Größe</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="982"/>
+        <source>Please adjust the size parameters of a single product item.</source>
+        <translation>Bitte geben Sie die folgenden Größenwerte des einzelnen Etiketts oder der einzelnen Karte in Ihrer Vorlage an.</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::TemplateDesignerEllipsePage</name>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="909"/>
+        <source>Product Size</source>
+        <translation>Größe</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="910"/>
+        <source>Please adjust the size parameters of a single product item.</source>
+        <translation>Bitte passen Sie die Größenwerte des einzelnen Etiketts oder der einzelnen Karte an.</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::TemplateDesignerIntroPage</name>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="553"/>
+        <source>Welcome</source>
+        <translation>Willkommen</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="554"/>
+        <source>Welcome to the gLabels Product Template Designer.</source>
+        <translation>Willkommen zum Vorlagendesigner von gLabels.</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::TemplateDesignerNLayoutsPage</name>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="1067"/>
+        <source>Number of Layouts</source>
+        <translation>Anzahl der Layouts</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="1068"/>
+        <source>Please select the number of layouts required.</source>
+        <translation>Bitte geben Sie die Anzahl der benötigten Layouts ein.</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::TemplateDesignerNamePage</name>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="604"/>
+        <source>Name and Description</source>
+        <translation>Name und Beschreibung</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="605"/>
+        <source>Please enter the following identifying information about the product.</source>
+        <translation>Bitte geben Sie die folgenden Identifizierungsinformationen zum Produkt ein.</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="636"/>
+        <source>Brand and part number match an existing built-in product template!</source>
+        <translation>Marke und Bestellnummer entsprechen einem existierenden Produkt in der Datenbank!</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::TemplateDesignerOneLayoutPage</name>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="1098"/>
+        <source>Layout</source>
+        <translation>Layout</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="1099"/>
+        <source>Please enter parameters for your single layout.</source>
+        <translation>Bitte geben Sie die folgenden Größenwerte für ein einzelnes Layout an.</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::TemplateDesignerPageSizePage</name>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="654"/>
+        <source>Page Size</source>
+        <translation>Seitengröße</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="655"/>
+        <source>Please select the product page size.</source>
+        <translation>Bitte geben Sie die Seitengröße des Produkts an.</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="660"/>
+        <location filename="../glabels/TemplateDesigner.cpp" line="668"/>
+        <location filename="../glabels/TemplateDesigner.cpp" line="674"/>
+        <location filename="../glabels/TemplateDesigner.cpp" line="676"/>
+        <location filename="../glabels/TemplateDesigner.cpp" line="708"/>
+        <location filename="../glabels/TemplateDesigner.cpp" line="715"/>
+        <location filename="../glabels/TemplateDesigner.cpp" line="716"/>
+        <source>Other</source>
+        <translation>Andere</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::TemplateDesignerRectPage</name>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="758"/>
+        <source>Product Size</source>
+        <translation>Größe</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="759"/>
+        <source>Please adjust the size parameters of a single product item.</source>
+        <translation>Bitte passen Sie die Größenwerte des einzelnen Etiketts oder der einzelnen Karte an.</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::TemplateDesignerRoundPage</name>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="844"/>
+        <source>Product Size</source>
+        <translation>Größe</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="845"/>
+        <source>Please adjust the size parameters of a single product item.</source>
+        <translation>Bitte passen Sie die Größenwerte des einzelnen Etiketts oder der einzelnen Karte an.</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::TemplateDesignerShapePage</name>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="725"/>
+        <source>Product Shape</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="726"/>
+        <source>Please select the basic product shape.</source>
+        <translation>Bitte geben Sie die grundlegende Form des Produkts an.</translation>
+    </message>
+</context>
+<context>
+    <name>glabels::TemplateDesignerTwoLayoutPage</name>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="1220"/>
+        <source>Layouts</source>
+        <translation>Layouts</translation>
+    </message>
+    <message>
+        <location filename="../glabels/TemplateDesigner.cpp" line="1221"/>
+        <source>Please enter parameters for your two layouts.</source>
+        <translation>Bitte geben Sie die Größenwerte für zwei Layouts an.</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../glabels/main.cpp" line="80"/>
+        <source>gLabels Label Designer</source>
+        <translation>gLabels Label Designer</translation>
+    </message>
+    <message>
+        <location filename="../glabels/main.cpp" line="84"/>
+        <source>gLabels project files to open, optionally.</source>
+        <translation>Zu öffnende gLabels-Projektdateien, optional.</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Hi Jim,

the German GUI translation is finished, taken from the existing po file.

However, it was a lot of work to import the strings. There's a conversion tool named po2ts from Translate toolkit [1], but it doesn't work really fine and need many manual corrections. Would be annoying for the current translators. They have to switch from their favorite po editors to Qtlinguist (or just a simple text editor) and additionally, they cannot import the po file directly. What about to use Gettext again?

Besides that, gLabels would need a new translation platform. The current Gnome i18n cannot be used anymore, even in that case you switch back to Gettext.

[1] http://docs.translatehouse.org/projects/translate-toolkit/en/latest/commands/ts2po.html?id=toolkit/ts2po