### PR TITLE
Fix typos in translatable strings

### DIFF
--- a/glabels/ui/TemplateDesignerOneLayoutPage.ui
+++ b/glabels/ui/TemplateDesignerOneLayoutPage.ui
@@ -79,7 +79,7 @@
      <item row="3" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
-        <string>Distance from top edge (y0);</string>
+        <string>Distance from top edge (y0):</string>
        </property>
       </widget>
      </item>

--- a/glabels/ui/TemplateDesignerTwoLayoutPage.ui
+++ b/glabels/ui/TemplateDesignerTwoLayoutPage.ui
@@ -71,7 +71,7 @@
      <item row="3" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
-        <string>Distance from top edge (y0);</string>
+        <string>Distance from top edge (y0):</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
There are two typos in the ui files which have been found by Qtlinguist.