### PR TITLE
Preview - Add label index overlay text to preview screen

### DIFF
--- a/glabels/Preview.cpp
+++ b/glabels/Preview.cpp
@@ -46,6 +46,10 @@ namespace glabels
 		const QColor  labelColor( 255, 255, 255 );
 		const QColor  labelOutlineColor( 215, 215, 215 );
 		const double  labelOutlineWidthPixels = 1;
+
+		const QColor  labelNumberColor( 192, 192, 255, 128 );
+		const QString labelNumberFontFamily( "Sans" );
+		const double  labelNumberScale = 0.5;
 	}
 
 
@@ -101,9 +105,43 @@ namespace glabels
 			drawPaper( mModel->tmplate()->pageWidth(), mModel->tmplate()->pageHeight() );
 			drawLabels();
 			drawPreviewOverlay();
+			drawLabelNumberOverlay();
 		}
 	}
 
+	void Preview::drawLabelNumberOverlaySingle(const model::Distance& x, const model::Distance& y, const QPainterPath& path, uint32_t labelInstance)
+	{
+		QBrush brush( labelNumberColor );
+
+		model::Frame *frame = mModel->tmplate()->frames().first();
+
+		model::Distance w = frame->w();
+		model::Distance h = frame->h();
+
+		model::Distance minWH = min( w, h );
+
+		auto labelText = QString::number(labelInstance);
+		QGraphicsSimpleTextItem *labelNumberItem = new QGraphicsSimpleTextItem( labelText );
+		labelNumberItem->setBrush( brush );
+		labelNumberItem->setFont( QFont( labelNumberFontFamily, minWH.pt()*labelNumberScale, QFont::Bold ) );
+		labelNumberItem->setPos( (x+w/2).pt(), (y+h/2).pt() );
+		QRectF rect = labelNumberItem->boundingRect();
+		labelNumberItem->setPos(labelNumberItem->x() - (rect.width() / 2), labelNumberItem->y() - (rect.height() / 2));
+
+		mScene->addItem( labelNumberItem );
+	}
+
+	void Preview::drawLabelNumberOverlay()
+	{
+		model::Frame *frame = mModel->tmplate()->frames().first();
+		auto i = 0;
+
+		foreach (model::Point origin, frame->getOrigins() )
+		{
+			i++;
+			drawLabelNumberOverlaySingle( origin.x(), origin.y(), frame->path(), i);
+		}
+	}
 
 	///
 	/// Resize Event Handler

--- a/glabels/Preview.h
+++ b/glabels/Preview.h
@@ -75,6 +75,9 @@ namespace glabels
 		
 		void drawPreviewOverlay();
 
+		void drawLabelNumberOverlaySingle(const model::Distance& x, const model::Distance& y, const QPainterPath& path, uint32_t labelInstance);
+		void drawLabelNumberOverlay();
+
 
 		/////////////////////////////////
 		// Private Data


### PR DESCRIPTION
First draft of adding label index overlay text to the preview screen. The snprintf() seemed like it could be out of place but I didn't see any other value to string conversion going on. Also it didn't seem great to assume the order of the origins corresponding to the index of the label, unless of course that is a safe assumption.

I also didn't see any rotation support in the preview screen so maybe the rotation flag and code can/should be removed if it isn't necessary.