### PR TITLE
Add BUGS sections to man pages

### DIFF
--- a/user-docs/conf.py
+++ b/user-docs/conf.py
@@ -149,8 +149,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('man/glabels-qt', 'glabels-qt', 'gLabels Documentation', [author], 1),
-    ('man/glabels-batch-qt', 'glabels-batch-qt', 'gLabels Documentation', [author], 1)
+    ('man/glabels-qt', 'glabels-qt', 'create labels and business cards', [author], 1),
+    ('man/glabels-batch-qt', 'glabels-batch-qt', 'batch creation of labels and business cards', [author], 1)
 ]
 
 

--- a/user-docs/man/glabels-batch-qt.rst
+++ b/user-docs/man/glabels-batch-qt.rst
@@ -79,6 +79,18 @@ FILES
 	      
               Directory for manually created product templates.
 
+BUGS
+----
+
+To report a bug or make a suggestion regarding this application or this manual
+page, you can use the issues section at Github:
+
+<https://github.com/jimevins/glabels-qt/issues>
+
+It is needed to register/sign in before. In case of you use another locale than
+**en** on your system, it would be very helpful for developers if you set the
+locale back to American English with the command ``export LC_ALL=C`` before
+launching `glabels-qt`.
 
 SEE ALSO
 --------

--- a/user-docs/man/glabels-qt.rst
+++ b/user-docs/man/glabels-qt.rst
@@ -43,6 +43,18 @@ FILES
 	      
               Directory for manually created product templates.
 
+BUGS
+----
+
+To report a bug or make a suggestion regarding this application or this manual
+page, you can use the issues section at Github:
+
+<https://github.com/jimevins/glabels-qt/issues>
+
+It is needed to register/sign in before. In case of you use another locale than
+**en** on your system, it would be very helpful for developers if you set the
+locale back to American English with the command ``export LC_ALL=C`` before
+launching `glabels-qt`.
 
 SEE ALSO
 --------


### PR DESCRIPTION
This adds a BUGS section to the existing man pages, describing where to file a bug, and with some extra instructions.