### PR TITLE
Fix typo

### DIFF
--- a/user-docs/man/glabels-batch-qt.rst
+++ b/user-docs/man/glabels-batch-qt.rst
@@ -82,7 +82,7 @@ FILES
 BUGS
 ----
 
-Bugs and featue requests can be reported via the gLabels issue tracking system at GitHub (<https://github.com/jimevins/glabels-qt/issues>).  You will need a GitHub account to submit new issues or to comment on existing issues.
+Bugs and feature requests can be reported via the gLabels issue tracking system at GitHub (<https://github.com/jimevins/glabels-qt/issues>).  You will need a GitHub account to submit new issues or to comment on existing issues.
 
 SEE ALSO
 --------

--- a/user-docs/man/glabels-qt.rst
+++ b/user-docs/man/glabels-qt.rst
@@ -46,7 +46,7 @@ FILES
 BUGS
 ----
 
-Bugs and featue requests can be reported via the gLabels issue tracking system at GitHub (<https://github.com/jimevins/glabels-qt/issues>).  You will need a GitHub account to submit new issues or to comment on existing issues.
+Bugs and feature requests can be reported via the gLabels issue tracking system at GitHub (<https://github.com/jimevins/glabels-qt/issues>).  You will need a GitHub account to submit new issues or to comment on existing issues.
 
 
 SEE ALSO


### PR DESCRIPTION
This fixes a typo in the man pages (featue → feature).