### PR TITLE
increase the maximum label by sheet, to allow to print at least a full page of label

### DIFF
--- a/glabels/ui/PrintView.ui
+++ b/glabels/ui/PrintView.ui
@@ -108,7 +108,7 @@
              <number>1</number>
             </property>
             <property name="maximum">
-             <number>96</number>
+             <number>999</number>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
For example, a sheet using Avery 8658 (7 x 27) has 189 labels on one sheet.

The diff changes the hardcoded `96` max value to `999` to allow a large serie of templates to print at least a full page. A maximum value is required as [QSpinBox](https://doc.qt.io/qt-5/qspinbox.html#maximum-prop) defines it to `99` if unset.

Closes: #51

Please note I tested the change on OpenBSD amd64.