### PR TITLE
Add missing loadRectSizePage for barcode

### DIFF
--- a/glabels/ObjectEditor.cpp
+++ b/glabels/ObjectEditor.cpp
@@ -454,8 +454,8 @@ namespace glabels
 
 					loadTextPage();
 					loadPositionPage();
+					loadRectSizePage();
 					loadShadowPage();
-                                        loadRectSizePage();
 				
 					setEnabled( true );
 				}
@@ -473,6 +473,7 @@ namespace glabels
 
 					loadBarcodePage();
 					loadPositionPage();
+					loadRectSizePage();
 				
 					setEnabled( true );
 				}


### PR DESCRIPTION
Add missing `loadRectSizePage()` to barcode case in `ObjectEditor::onSelectionChanged()`. Also align that in text case.