### PR TITLE
Style equality; BarcodeMenu checks; sample record

### DIFF
--- a/backends/barcode/Backends.cpp
+++ b/backends/barcode/Backends.cpp
@@ -56,25 +56,25 @@ namespace glabels
 			               true, false, true, false, "123456789012", false, 12 );
 
 			registerStyle( "postnet", "", tr("POSTNET (any)"),
-			               false, false, true, false, "12345-6789-12", false, 11 );
+			               false, false, true, false, "12345-6789-12", false, 11, true, true );
 
 			registerStyle( "postnet-5", "", tr("POSTNET-5 (ZIP only)"),
-			               false, false, true, false, "12345", false, 5 );
+			               false, false, true, false, "12345", false, 5, true, true );
 
 			registerStyle( "postnet-9", "", tr("POSTNET-9 (ZIP+4)"),
-			               false, false, true, false, "12345-6789", false, 9 );
+			               false, false, true, false, "12345-6789", false, 9, true, true );
 
 			registerStyle( "postnet-11", "", tr("POSTNET-11 (DPBC)"),
-			               false, false, true, false, "12345-6789-12", false, 11 );
+			               false, false, true, false, "12345-6789-12", false, 11, true, true );
 
 			registerStyle( "cepnet", "", tr("CEPNET"),
-			               false, false, true, false, "12345-678", false, 8 );
+			               false, false, true, false, "12345-678", false, 8, true, true );
 
 			registerStyle( "onecode", "", tr("USPS Intelligent Mail"),
-			               false, false, true, false, "12345678901234567890", false, 20 );
+			               false, false, true, false, "12345678901234567890", false, 20, true, true );
 
-			registerStyle( "datamatrix", "", tr("IEC16022 (DataMatrix)"),
-			               false, false, true, false, "1234567890AB", false, 12 );
+			registerStyle( "datamatrix", "", tr("Data Matrix (IEC16022)"),
+			               false, false, true, false, "123456ABCD", true, 10, true ); // Default 14x14 symbol size, 8 data (3 for packed digits + 3/4 for letters)
 
 #if HAVE_GNU_BARCODE
 			//
@@ -137,27 +137,27 @@ namespace glabels
 			registerStyle( "upc-e+5", "gnu-barcode", tr("UPC-E +5"),
 			               true, true, true, false, "000000 00000", false, 11 );
 			registerStyle( "isbn", "gnu-barcode", tr("ISBN"),
-			               true, true, true, true, "0-00000-000-0", false, 10 );
+			               true, true, true, false, "0-00000-000-0", false, 10 );
 			registerStyle( "isbn+5", "gnu-barcode", tr("ISBN +5"),
-			               true, true, true, true, "0-00000-000-0 00000", false, 15 );
+			               true, true, true, false, "0-00000-000-0 00000", false, 15 );
 			registerStyle( "code39", "gnu-barcode", tr("Code 39"),
 			               true, true, true, true, "0000000000", true, 10 );
 			registerStyle( "code128", "gnu-barcode", tr("Code 128"),
-			               true, true, true, true, "0000000000", true, 10 );
+			               true, true, true, false, "0000000000", true, 10 );
 			registerStyle( "code128c", "gnu-barcode", tr("Code 128C"),
 			               true, true, true, false, "0000000000", true, 10 );
 			registerStyle( "code128b", "gnu-barcode", tr("Code 128B"),
-			               true, true, true, true, "0000000000", true, 10 );
+			               true, true, true, false, "0000000000", true, 10 );
 			registerStyle( "i25", "gnu-barcode", tr("Interleaved 2 of 5"),
 			               true, true, true, true, "0000000000", true, 10 );
 			registerStyle( "cbr", "gnu-barcode", tr("Codabar"),
-			               true, true, true, true, "0000000000", true, 10 );
+			               true, true, true, true, "A00000000B", true, 10 );
 			registerStyle( "msi", "gnu-barcode", tr("MSI"),
 			               true, true, true, true, "0000000000", true, 10 );
 			registerStyle( "pls", "gnu-barcode", tr("Plessey"),
-			               true, true, true, true, "0000000000", true, 10 );
-			registerStyle( "code93", "gnu-barcode", tr("Code 93"),
 			               true, true, true, false, "0000000000", true, 10 );
+			registerStyle( "code93", "gnu-barcode", tr("Code 93"),
+			               true, true, true, true, "0000000000", true, 10 );
 #endif // HAVE_GNU_BARCODE
 
 #if HAVE_QRENCODE
@@ -168,8 +168,8 @@ namespace glabels
 		
 			glbarcode::Factory::registerType( "qrencode::qrcode", QrEncode::QrCode::create );
 
-			registerStyle( "qrcode", "qrencode", tr("IEC18004 (QRCode)"),
-			               false, false, true, false, "1234567890AB", false, 12 );
+			registerStyle( "qrcode", "qrencode", tr("QR Code (IEC18004)"),
+			               false, false, true, false, "1234567890AB", true, 12, true );
 #endif // HAVE_QRENCODE
 
 #if HAVE_ZINT
@@ -247,55 +247,55 @@ namespace glabels
 			glbarcode::Factory::registerType( "zint::pls",       Zint::Pls::create );
 
 			registerStyle( "ausp", "zint", tr("Australia Post Standard"),
-			               false, false, true, false, "12345678901234567890123", true, 23 );
+			               false, false, true, false, "12345678901234567890123", false, 23, true, true );
 
 			registerStyle( "ausrp", "zint", tr("Australia Post Reply Paid"),
-			               false, false, true, false, "12345678", true, 8 );
+			               false, false, true, false, "12345678", true, 8, true, true );
 
 			registerStyle( "ausrt", "zint", tr("Australia Post Route Code"),
-			               false, false, true, false, "12345678", true, 8 );
+			               false, false, true, false, "12345678", true, 8, true, true );
 
 			registerStyle( "ausrd", "zint", tr("Australia Post Redirect"),
-			               false, false, true, false, "12345678", true, 8 );
+			               false, false, true, false, "12345678", true, 8, true, true );
 
 			registerStyle( "aztec", "zint", tr("Aztec Code"),
-			               false, false, true, false, "1234567890", true, 10 );
+			               false, false, true, false, "1234567890AB", true, 12, true );
           
 			registerStyle( "azrun", "zint", tr("Aztec Rune"),
-			               false, false, true, false, "255", true, 3 );
+			               false, false, true, false, "255", true, 3, true );
 
 			registerStyle( "cbr", "zint", tr("Codabar"),
-			               true, true, true, false, "ABCDABCDAB", true, 10 );
+			               true, true, false, false, "A00000000B", true, 10 );
 
 			registerStyle( "code1", "zint", tr("Code One"), 
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "0000000000", true, 10, true );
 
 			registerStyle( "code11", "zint", tr("Code 11"),
 			               true, true, true, false, "0000000000", true, 10 );
           
 			registerStyle( "c16k", "zint", tr("Code 16K"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "0000000000", true, 10, true );
           
 			registerStyle( "c25m", "zint", tr("Code 2 of 5 Matrix"), 
-			               true, true, true, false, "0000000000", true, 10 );
+			               true, true, false, false, "0000000000", true, 10 );
           
 			registerStyle( "c25i", "zint", tr("Code 2 of 5 IATA"), 
-			               true, true, true, false, "0000000000", true, 10 );
+			               true, true, false, false, "0000000000", true, 10 );
           
 			registerStyle( "c25dl", "zint", tr("Code 2 of 5 Data Logic"), 
-			               true, true, true, false, "0000000000", true, 10 );
+			               true, true, false, false, "0000000000", true, 10 );
 
 			registerStyle( "code32", "zint", tr("Code 32 (Italian Pharmacode)"), 
 			               true, true, true, false, "12345678", true, 8 );
 
 			registerStyle( "code39", "zint", tr("Code 39"),
-			               true, true, false, false, "0000000000", true, 10 );
+			               true, true, true, true, "0000000000", true, 10 );
           
 			registerStyle( "code39e", "zint", tr("Code 39 Extended"), 
-			               true, true, true, false, "0000000000", true, 10 );
+			               true, true, true, true, "0000000000", true, 10 );
 
 			registerStyle( "code49", "zint", tr("Code 49"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "0000000000", true, 10, true );
 
 			registerStyle( "code93", "zint", tr("Code 93"),
 			               true, true, true, false, "0000000000", true, 10 );
@@ -307,10 +307,10 @@ namespace glabels
 			               true, true, true, false, "0000000000", true, 10 );
           
 			registerStyle( "daft", "zint", tr("DAFT Code"),
-			               false, false, false, false, "DAFTDAFTDAFTDAFT", true, 16 );
+			               false, false, false, false, "DAFTDAFTDAFTDAFT", true, 16, true );
 
 			registerStyle( "dmtx", "zint", tr("Data Matrix"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "123456ABCD", true, 10, true ); // Default 14x14 symbol size, 8 data (3 for packed digits + 3/4 for letters)
 
 			registerStyle( "dpl", "zint", tr("Deutsche Post Leitcode"),
 			               true, true, true, false, "1234567890123", true, 13 );
@@ -319,15 +319,15 @@ namespace glabels
 			               true, true, true, false, "12345678901", true, 11 );
           
 			registerStyle( "kix", "zint", tr("Dutch Post KIX Code"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, false, false, "123456ABCDE", false, 11, true, true );
 
 			registerStyle( "ean", "zint", tr("EAN"),
-			               true, true, true, false, "1234567890123", false, 13 );
+			               true, true, true, false, "123456789012", false, 12 );
 
 			registerStyle( "gmtx", "zint", tr("Grid Matrix"), 
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "0000000000", true, 10, true );
 
-			registerStyle( "gs1-128", "zint", tr("GS1-128"),
+			registerStyle( "gs1128", "zint", tr("GS1-128"),
 			               true, true, true, false, "[01]12345678901234", false, 18 );
 
 			registerStyle( "rss14", "zint", tr("GS1 DataBar-14"),
@@ -340,13 +340,13 @@ namespace glabels
 			               true, true, true, false, "[01]12345678901234", false, 18 );
           
 			registerStyle( "rsss", "zint", tr("GS1 DataBar-14 Stacked"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "0000000000000", true, 13, true );
 
 			registerStyle( "rssso", "zint", tr("GS1 DataBar-14 Stacked Omni."),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "0000000000000", true, 13, true );
 
 			registerStyle( "rssse", "zint", tr("GS1 DataBar Extended Stacked"),
-			               false, false, true, false, "[01]12345678901234", false, 18 );
+			               false, false, true, false, "[01]12345678901234", false, 18, true );
 
 			registerStyle( "hibc128", "zint", tr("HIBC Code 128"),
 			               true, true, true, false, "0000000000", true, 10 );
@@ -355,31 +355,31 @@ namespace glabels
 			               true, true, true, false, "0000000000", true, 10 );
 
 			registerStyle( "hibcdm", "zint", tr("HIBC Data Matrix"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "123456ABCD", true, 10, true ); // Default 14x14 symbol size, 8 data (3 for packed digits + 3/4 for letters)
 
 			registerStyle( "hibcqr", "zint", tr("HIBC QR Code"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "1234567890AB", true, 12, true );
 
 			registerStyle( "hibcpdf", "zint", tr("HIBC PDF417"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "0000000000", true, 10, true );
 
 			registerStyle( "hibcmpdf", "zint", tr("HIBC Micro PDF417"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "0000000000", true, 10, true );
 
 			registerStyle( "hibcaz", "zint", tr("HIBC Aztec Code"),
-			               true, true, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "1234567890AB", true, 12, true );
 
 			registerStyle( "i25", "zint", tr("Interleaved 2 of 5"),
-			               true, true, true, false, "0000000000", true, 10 );
+			               true, true, false, false, "0000000000", true, 10 );
 
 			registerStyle( "isbn", "zint", tr("ISBN"),
-			               true, true, true, false, "123456789", false, 9 );
+			               true, true, true, false, "123456789", false, 9, true );
 
 			registerStyle( "itf14", "zint", tr("ITF-14"),
 			               true, true, true, false, "0000000000", true, 10 );
 
 			registerStyle( "japan", "zint", tr("Japanese Postal"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "0000000000", true, 10, true );
 
 			registerStyle( "korea", "zint", tr("Korean Postal"),
 			               true, true, true, false, "123456", false, 6 );
@@ -388,13 +388,13 @@ namespace glabels
 			               true, true, true, false, "0000000000", true, 10 );
 
 			registerStyle( "maxi", "zint", tr("Maxicode"),
-			               false, false, false, false, "0000000000", true, 10 );
+			               false, false, false, false, "0000000000", true, 10, true, true );
 
 			registerStyle( "mpdf", "zint", tr("Micro PDF417"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "0000000000", true, 10, true );
 
 			registerStyle( "mqr", "zint", tr("Micro QR Code"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "0000000000", true, 10, true );
 
 			registerStyle( "msi", "zint", tr("MSI Plessey"),
 			               true, true, true, false, "0000000000", true, 10 );
@@ -403,16 +403,16 @@ namespace glabels
 			               true, true, true, false, "12345678901234567", false, 17 );
 
 			registerStyle( "pdf", "zint", tr("PDF417"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "0000000000", true, 10, true );
 
 			registerStyle( "pdft", "zint", tr("PDF417 Truncated"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "0000000000", true, 10, true );
 
 			registerStyle( "plan", "zint", tr("PLANET"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "00000000000", true, 11, true, true );
 
 			registerStyle( "postnet", "zint", tr("PostNet"),
-			               true, true, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "00000000000", true, 11, true, true );
 
 			registerStyle( "pharma", "zint", tr("Pharmacode"),
 			               false, false, true, false, "123456", false, 6 );
@@ -424,10 +424,10 @@ namespace glabels
 			               true, true, true, false, "123456", false, 6 );
 
 			registerStyle( "qr", "zint", tr("QR Code"),
-			               true, true, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "1234567890AB", true, 12, true );
 
 			registerStyle( "rm4", "zint", tr("Royal Mail 4-State"),
-			               false, false, true, false, "0000000000", true, 10 );
+			               false, false, true, false, "0000000000", true, 10, true, true );
 
 			registerStyle( "tele", "zint", tr("Telepen"),
 			               true, true, true, false, "0000000000", true, 10 );
@@ -436,13 +436,13 @@ namespace glabels
 			               true, true, true, false, "0000000000", true, 10 );
 
 			registerStyle( "upc-a", "zint", tr("UPC-A"), 
-			               true, true, true, false, "12345678901", false, 11 );
+			               true, true, true, false, "12345678901", false, 11, true );
           
 			registerStyle( "upc-e", "zint", tr("UPC-E"), 
-			               true, true, true, false, "1234567", false, 7 );
+			               true, true, true, false, "1234567", false, 7, true );
           
 			registerStyle( "usps", "zint", tr("USPS One Code"),
-			               false, false, true, false, "12345678901234567890", true, 20 );
+			               false, false, true, false, "12345678901234567890", true, 20, true );
 
 			registerStyle( "pls", "zint", tr("UK Plessey"),
 			               true, true, true, false, "0000000000", true, 10 );
@@ -516,13 +516,16 @@ namespace glabels
 		                              bool           checksumOptional,
 		                              const QString& defaultDigits,
 		                              bool           canFreeForm,
-		                              int            preferedN )
+		                              int            preferedN,
+		                              bool           fixedAspectRatio,
+		                              bool           fixedSize )
 		{
 			Style style( id, backendId, name,
 			             canText, textOptional,
 			             canChecksum, checksumOptional,
 			             defaultDigits,
-			             canFreeForm, preferedN );
+			             canFreeForm, preferedN,
+			             fixedAspectRatio, fixedSize );
 
 			mStyleList.append( style );
 		}

--- a/backends/barcode/Backends.h
+++ b/backends/barcode/Backends.h
@@ -78,7 +78,9 @@ namespace glabels
 			                           bool           checksumOptional,
 			                           const QString& defaultDigits,
 			                           bool           canFreeForm,
-			                           int            preferedN );
+			                           int            preferedN,
+			                           bool           fixedAspectRatio = false,
+			                           bool           fixedSize = false );
 
 
 			/////////////////////////////////

--- a/backends/barcode/GnuBarcode.h
+++ b/backends/barcode/GnuBarcode.h
@@ -25,6 +25,8 @@
 
 #include "glbarcode/Barcode1dBase.h"
 
+struct Barcode_Item; /* Forward reference. */
+
 
 namespace glabels
 {
@@ -41,22 +43,13 @@ namespace glabels
 			class Base : public glbarcode::Barcode1dBase
 			{
 			protected:
+				Barcode_Item* bci;
 				int flags;
 			
-				bool isAscii( const std::string& data ) const;
-			
-				bool isNumericLengthValid( const std::string& data,
-				                           unsigned int       nMin,
-				                           unsigned int       nMax ) const;
+				Base();
 
-				bool isNumericLength1Valid( const std::string& data,
-				                            unsigned int       nMin,
-				                            unsigned int       nMax ) const;
+				bool validate( const std::string& rawData ) override;
 
-				bool isNumericLength2Valid( const std::string& data,
-				                            unsigned int       nMin,
-				                            unsigned int       nMax ) const;
-			
 				void vectorize( const std::string& encodedData,
 				                const std::string& displayText,
 				                const std::string& cookedData,
@@ -74,7 +67,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -88,7 +80,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -102,7 +93,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -116,7 +106,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -130,7 +119,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -144,7 +132,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -158,7 +145,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -172,7 +158,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -186,7 +171,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -200,7 +184,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -214,7 +197,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -228,7 +210,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -242,7 +223,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -256,7 +236,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -270,7 +249,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -284,7 +262,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -298,7 +275,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -312,7 +288,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -326,7 +301,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -340,7 +314,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -354,7 +327,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -368,7 +340,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -382,7 +353,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -396,7 +366,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 
@@ -410,7 +379,6 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
-				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 

--- a/backends/barcode/Style.cpp
+++ b/backends/barcode/Style.cpp
@@ -39,7 +39,9 @@ namespace glabels
 			  mChecksumOptional( false ),
 			  mDefaultDigits( "" ),
 			  mCanFreeform( false ),
-			  mPreferedN( 0 )
+			  mPreferedN( 0 ),
+			  mFixedAspectRatio( false ),
+			  mFixedSize( false )
 		{
 			// empty
 		}
@@ -57,7 +59,9 @@ namespace glabels
 		               bool           checksumOptional,
 		               const QString& defaultDigits,
 		               bool           canFreeform,
-		               int            preferedN )
+		               int            preferedN,
+		               bool           fixedAspectRatio,
+		               bool           fixedSize )
 			: mId( id ),
 			  mBackendId( backendId ),
 			  mName( name ),
@@ -67,7 +71,9 @@ namespace glabels
 			mChecksumOptional( checksumOptional ),
 			mDefaultDigits( defaultDigits ),
 			mCanFreeform( canFreeform ),
-			mPreferedN( preferedN )
+			mPreferedN( preferedN ),
+			mFixedAspectRatio( fixedAspectRatio ),
+			mFixedSize ( fixedSize )
 		{
 			// empty
 		}
@@ -180,6 +186,24 @@ namespace glabels
 
 
 		///
+		/// Fixed Aspect Ratio Property Getter
+		///
+		bool Style::fixedAspectRatio() const
+		{
+			return mFixedAspectRatio;
+		}
+
+
+		///
+		/// Fixed Size Property Getter
+		///
+		bool Style::fixedSize() const
+		{
+			return mFixedSize;
+		}
+
+
+		///
 		/// Generate Example Digits
 		///
 		QString Style::exampleDigits( int n ) const
@@ -200,7 +224,7 @@ namespace glabels
 		///
 		bool Style::operator!=( const Style& other ) const
 		{
-			return mId != other.mId;
+			return mId != other.mId || mBackendId != other.mBackendId;
 		}
 	
 	} // namespace barcode

--- a/backends/barcode/Style.h
+++ b/backends/barcode/Style.h
@@ -51,7 +51,9 @@ namespace glabels
 			        bool           checksumOptional,
 			        const QString& defaultDigits,
 			        bool           canFreeform,
-			        int            preferedN );
+			        int            preferedN,
+			        bool           fixedAspectRatio = false,
+			        bool           fixedSize = false );
 
 
 			/////////////////////////////////
@@ -78,6 +80,10 @@ namespace glabels
 			bool canFreeform() const;
 
 			int preferedN() const;
+
+			bool fixedAspectRatio() const;
+
+			bool fixedSize() const;
 
 
 			/////////////////////////////////
@@ -108,6 +114,8 @@ namespace glabels
 			QString mDefaultDigits;
 			bool    mCanFreeform;
 			int     mPreferedN;
+			bool    mFixedAspectRatio;
+			bool    mFixedSize;
 
 		};
 

--- a/backends/barcode/Zint.h
+++ b/backends/barcode/Zint.h
@@ -25,6 +25,8 @@
 
 #include "glbarcode/Barcode1dBase.h"
 
+struct zint_symbol; /* Forward reference. */
+
 
 namespace glabels
 {
@@ -41,9 +43,13 @@ namespace glabels
 			class Base : public glbarcode::Barcode1dBase
 			{
 			protected:
+				struct zint_symbol* symbol;
 				int symbology;
+				int option_2;
 			
 			
+				Base();
+
 				bool validate( const std::string& rawData ) override;
 
 				void vectorize( const std::string& encodedData,
@@ -895,6 +901,7 @@ namespace glabels
 				static Barcode* create();
 			
 			protected:
+				bool validate( const std::string& rawData ) override;
 				std::string encode( const std::string& cookedData ) override;
 			};
 

--- a/backends/merge/Merge.cpp
+++ b/backends/merge/Merge.cpp
@@ -22,6 +22,8 @@
 
 #include "Record.h"
 
+#include <QRegularExpression>
+
 
 namespace glabels
 {
@@ -102,6 +104,46 @@ namespace glabels
 		const QList<Record*>& Merge::recordList( ) const
 		{
 			return mRecordList;
+		}
+
+
+		///
+		/// Get sample record
+		///
+		Record* Merge::sampleRecord() const
+		{
+			if ( mRecordList.isEmpty() )
+			{
+				return nullptr;
+			}
+
+			const QList<Record*> selected = selectedRecords();
+
+			Record* sampleRecord = new Record;
+
+			foreach ( Record* record, selected.isEmpty() ? mRecordList : selected )
+			{
+				QList<QString> keys = record->keys();
+				foreach ( QString key, keys )
+				{
+					if ( !sampleRecord->contains( key ) || (*sampleRecord)[key].size() < (*record)[key].size() )
+					{
+						(*sampleRecord)[key] = (*record)[key];
+					}
+				}
+			}
+
+			QRegularExpression numerics( "[0-9]" );
+			QRegularExpression uppers( "\\p{Lu}" );
+			QRegularExpression lowers( "\\p{Ll}" );
+
+			QList<QString> keys = sampleRecord->keys();
+			foreach ( QString key, keys )
+			{
+				(*sampleRecord)[key] = (*sampleRecord)[key].replace( numerics, "0" ).replace( uppers, "A" ).replace( lowers, "a" );
+			}
+
+			return sampleRecord;
 		}
 
 

--- a/backends/merge/Merge.cpp
+++ b/backends/merge/Merge.cpp
@@ -25,6 +25,12 @@
 #include <QRegularExpression>
 
 
+namespace
+{
+	const unsigned int maxSampleSize = 50; // Number of records to sample
+}
+
+
 namespace glabels
 {
 	namespace merge
@@ -121,6 +127,7 @@ namespace glabels
 
 			Record* sampleRecord = new Record;
 
+			unsigned int count = 0;
 			foreach ( Record* record, selected.isEmpty() ? mRecordList : selected )
 			{
 				QList<QString> keys = record->keys();
@@ -130,6 +137,10 @@ namespace glabels
 					{
 						(*sampleRecord)[key] = (*record)[key];
 					}
+				}
+				if ( ++count > maxSampleSize )
+				{
+					break;
 				}
 			}
 

--- a/backends/merge/Merge.h
+++ b/backends/merge/Merge.h
@@ -71,6 +71,8 @@ namespace glabels
 
 			const QList<Record*>& recordList( ) const;
 
+			Record* sampleRecord() const;
+
 
 			/////////////////////////////////
 			// Selection methods

--- a/glabels/BarcodeMenu.h
+++ b/glabels/BarcodeMenu.h
@@ -42,6 +42,7 @@ namespace glabels
 		/////////////////////////////////
 	public:
 		BarcodeMenu();
+		~BarcodeMenu() override;
 
 
 		/////////////////////////////////
@@ -56,6 +57,7 @@ namespace glabels
 		/////////////////////////////////
 	public:
 		barcode::Style bcStyle() const;
+		void setBcStyle( const barcode::Style& bcStyle );
 
 
 		/////////////////////////////////
@@ -70,6 +72,9 @@ namespace glabels
 		/////////////////////////////////
 	private:
 		barcode::Style mBcStyle;
+		QActionGroup*  mGroup;
+		QActionGroup*  mBackendGroup;
+		QAction*       mDummyBackendAction;
 
 	};
 

--- a/glabels/BarcodeMenuButton.cpp
+++ b/glabels/BarcodeMenuButton.cpp
@@ -47,6 +47,15 @@ namespace glabels
 
 
 	///
+	/// Destructor
+	///
+	BarcodeMenuButton::~BarcodeMenuButton()
+	{
+		delete mMenu;
+	}
+
+
+	///
 	/// bcStyle getter
 	///
 	barcode::Style BarcodeMenuButton::bcStyle() const
@@ -61,7 +70,27 @@ namespace glabels
 	void BarcodeMenuButton::setBcStyle( const barcode::Style& bcStyle )
 	{
 		mBcStyle = bcStyle;
-		setText( mBcStyle.name() );
+		if ( mBcStyle.backendId().isEmpty() )
+		{
+			setText( mBcStyle.name() );
+		}
+		else
+		{
+			/*
+			 * Translators: %1 = name of barcode package ("GNU Barcode", "QREncode", or "Zint")
+			 *              %2 = name of barcode ("Code 39", "EAN-13", "Data Matrix", "QR Code" etc)
+			 */
+			setText( tr("%1 - %2").arg( barcode::Backends::backendName( mBcStyle.backendId() ), mBcStyle.name() ) );
+		}
+	}
+
+
+	///
+	/// Set menu item active
+	///
+	void BarcodeMenuButton::setMenuItemActive()
+	{
+		mMenu->setBcStyle( mBcStyle );
 	}
 
 
@@ -70,8 +99,7 @@ namespace glabels
 	///
 	void BarcodeMenuButton::onMenuSelectionChanged()
 	{
-		mBcStyle = mMenu->bcStyle();
-		setText( mBcStyle.name() );
+		setBcStyle( mMenu->bcStyle() );
 
 		emit selectionChanged();
 	}

--- a/glabels/BarcodeMenuButton.h
+++ b/glabels/BarcodeMenuButton.h
@@ -44,6 +44,7 @@ namespace glabels
 		/////////////////////////////////
 	public:
 		BarcodeMenuButton( QWidget* parent = nullptr );
+		~BarcodeMenuButton() override;
 
 
 		/////////////////////////////////
@@ -59,6 +60,7 @@ namespace glabels
 	public:
 		barcode::Style bcStyle() const;
 		void setBcStyle( const barcode::Style& bcStyle );
+		void setMenuItemActive();
 
 
 		/////////////////////////////////

--- a/glabels/BarcodeMenuItem.cpp
+++ b/glabels/BarcodeMenuItem.cpp
@@ -33,6 +33,8 @@ namespace glabels
 		: QAction(parent), mBcStyle(bcStyle)
 	{
 		setText( bcStyle.name() );
+		setObjectName( bcStyle.fullId() );
+		setCheckable( true );
 
 		connect( this, SIGNAL(triggered()), this, SLOT(onTriggered()) );
 	}

--- a/glbarcode/Barcode.cpp
+++ b/glbarcode/Barcode.cpp
@@ -192,4 +192,90 @@ namespace glbarcode
 	}
 
 
+	uint32_t Barcode::decodeUTF8( uint32_t* state, uint32_t* codep, unsigned char byte )
+	{
+		/*
+		 * Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+		 * See https://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.
+		 */
+
+		static const uint8_t utf8d[] = {
+			/* The first part of the table maps bytes to character classes that
+			 * reduce the size of the transition table and create bitmasks. */
+			 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+			 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+			 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+			 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+			 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,  9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+			 7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+			 8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,  2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,
+			10,3,3,3,3,3,3,3,3,3,3,3,3,4,3,3, 11,6,6,6,5,8,8,8,8,8,8,8,8,8,8,8,
+
+			/* The second part is a transition table that maps a combination
+			 * of a state of the automaton and a character class to a state. */
+			 0,12,24,36,60,96,84,12,12,12,48,72, 12,12,12,12,12,12,12,12,12,12,12,12,
+			12, 0,12,12,12,12,12, 0,12, 0,12,12, 12,24,12,12,12,12,12,24,12,24,12,12,
+			12,12,12,12,12,12,12,24,12,12,12,12, 12,24,12,12,12,12,12,12,12,24,12,12,
+			12,12,12,12,12,12,12,36,12,36,12,12, 12,36,12,12,12,12,12,36,12,36,12,12,
+			12,36,12,12,12,12,12,12,12,12,12,12,
+		};
+
+		uint32_t type = utf8d[byte];
+
+		*codep = *state != 0 ? (byte & 0x3fu) | (*codep << 6) : (0xff >> type) & byte;
+
+		*state = utf8d[256 + *state + type];
+
+		return *state;
+	}
+
+
+	bool Barcode::isISO8859_1( const std::string& rawData )
+	{
+		uint32_t codepoint;
+		uint32_t state = 0;
+
+		for ( unsigned char c : rawData )
+		{
+			Barcode::decodeUTF8( &state, &codepoint, c );
+			if ( state == 12 || (state == 0 && codepoint >= 0x80 && (codepoint < 0xa0 || codepoint > 0xFF)) )
+			{
+				return false;
+			}
+		}
+
+		if ( state != 0 )
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+
+	std::string Barcode::toISO8859_1( const std::string& rawData )
+	{
+		std::string cookedData;
+
+		uint32_t codepoint;
+		uint32_t state = 0;
+
+		for ( unsigned char c : rawData )
+		{
+			if ( Barcode::decodeUTF8( &state, &codepoint, c ) == 0 )
+			{
+				if ( codepoint < 0x80 )
+				{
+					cookedData += c;
+				}
+				else if (codepoint >= 0xA0 && codepoint <= 0xFF )
+				{
+					cookedData += (unsigned char)codepoint;
+				}
+			}
+		}
+
+		return cookedData;
+	}
+
 }

--- a/glbarcode/Barcode.h
+++ b/glbarcode/Barcode.h
@@ -300,6 +300,13 @@ namespace glbarcode
 		void setHeight( double h );
 
 
+		static uint32_t decodeUTF8( uint32_t* state, uint32_t* codep, unsigned char byte );
+
+		static bool isISO8859_1( const std::string& rawData );
+
+		static std::string toISO8859_1( const std::string& rawData );
+
+
 	private:
 		/**
 		 * Barcode Private data

--- a/glbarcode/Barcode2dBase.cpp
+++ b/glbarcode/Barcode2dBase.cpp
@@ -33,7 +33,7 @@ using namespace glbarcode::Constants;
 namespace
 {
 
-	const double MIN_CELL_SIZE  = ( 0.0625 * PTS_PER_INCH );
+	const double MIN_CELL_SIZE  = 1;
 
 }
 

--- a/glbarcode/BarcodeDataMatrix.cpp
+++ b/glbarcode/BarcodeDataMatrix.cpp
@@ -580,7 +580,16 @@ namespace glbarcode
 	 */
 	bool BarcodeDataMatrix::validate( const std::string& rawData )
 	{
-		return true;
+		return Barcode::isISO8859_1( rawData );
+	}
+
+
+	/*
+	 * DataMatrix Pre-process data before encoding, implements Barcode2dBase::preprocess()
+	 */
+	std::string BarcodeDataMatrix::preprocess( const std::string& rawData )
+	{
+		return Barcode::toISO8859_1( rawData );
 	}
 
 

--- a/glbarcode/BarcodeDataMatrix.h
+++ b/glbarcode/BarcodeDataMatrix.h
@@ -50,6 +50,8 @@ namespace glbarcode
 	private:
 		bool validate( const std::string& rawData ) override;
 
+		std::string preprocess( const std::string& rawData ) override;
+
 		bool encode( const std::string& cookedData,
 		             Matrix<bool>&      encodedData ) override;
 

--- a/glbarcode/QtRenderer.cpp
+++ b/glbarcode/QtRenderer.cpp
@@ -30,6 +30,7 @@
 namespace
 {
 	const double FONT_SCALE = 0.75;
+	const double MIN_POINT_SIZE = 0.4; // Less than ~0.37 causes issues for QFontMetricsF
 }
 
 
@@ -131,7 +132,7 @@ namespace glbarcode
 			QFont font;
 			font.setStyleHint( QFont::Monospace );
 			font.setFamily( "monospace" );
-			font.setPointSizeF( FONT_SCALE*size );
+			font.setPointSizeF( std::max( FONT_SCALE*size, MIN_POINT_SIZE ) );
 
 			QFontMetricsF fm( font );
 			double xCorner = x - fm.width( QString::fromStdString(text) )/2.0;

--- a/model/Constants.h
+++ b/model/Constants.h
@@ -34,6 +34,8 @@ namespace glabels
 		const double PTS_PER_PICA  =  12.0;
 
 		const Distance EPSILON( 0.5, Units::PT );
+
+		const double MIN_POINT_SIZE = 0.4; // Less than ~0.37 causes issues for QFontMetricsF
 	}
 }
 

--- a/model/Model.cpp
+++ b/model/Model.cpp
@@ -73,6 +73,7 @@ namespace glabels
 		///
 		Model::~Model()
 		{
+			qDeleteAll( mObjectList );
 			// Final instance of mMerge to be deleted by Model owner
 		}
 
@@ -116,13 +117,15 @@ namespace glabels
 
 			foreach ( ModelObject* savedObject, savedModel->mObjectList )
 			{
-				ModelObject* object = savedObject->clone();
+				ModelObject* object = savedObject->clone( this );
 		
-				object->setParent( this );
 				mObjectList << object;
 
 				connect( object, SIGNAL(changed()), this, SLOT(onObjectChanged()) );
 				connect( object, SIGNAL(moved()), this, SLOT(onObjectMoved()) );
+
+				connect( this, SIGNAL(mergeSourceChanged()), object, SLOT(onMergeChanged()) );
+				connect( this, SIGNAL(mergeSelectionChanged()), object, SLOT(onMergeChanged()) );
 			}
 
 			// Emit signals based on potential changes
@@ -371,6 +374,9 @@ namespace glabels
 			connect( object, SIGNAL(changed()), this, SLOT(onObjectChanged()) );
 			connect( object, SIGNAL(moved()), this, SLOT(onObjectMoved()) );
 
+			connect( this, SIGNAL(mergeSourceChanged()), object, SLOT(onMergeChanged()) );
+			connect( this, SIGNAL(mergeSelectionChanged()), object, SLOT(onMergeChanged()) );
+
 			setModified();
 
 			emit changed();
@@ -386,6 +392,7 @@ namespace glabels
 			mObjectList.removeOne( object );
 
 			disconnect( object, nullptr, this, nullptr );
+			disconnect( this, nullptr, object, nullptr );
 
 			setModified();
 

--- a/model/ModelBarcodeObject.h
+++ b/model/ModelBarcodeObject.h
@@ -45,7 +45,7 @@ namespace glabels
 			// Lifecycle Methods
 			///////////////////////////////////////////////////////////////
 		public:
-			ModelBarcodeObject();
+			ModelBarcodeObject( QObject* parent = nullptr );
 
 			ModelBarcodeObject( const Distance&       x0,
 			                    const Distance&       y0,
@@ -59,7 +59,7 @@ namespace glabels
 			                    const ColorNode&      bcColorNode,
 			                    const QMatrix&        matrix = QMatrix() );
 
-			ModelBarcodeObject( const ModelBarcodeObject* object );
+			ModelBarcodeObject( const ModelBarcodeObject* object, QObject* parent = nullptr );
 
 			~ModelBarcodeObject() override;
 
@@ -67,7 +67,7 @@ namespace glabels
 			///////////////////////////////////////////////////////////////
 			// Object duplication
 			///////////////////////////////////////////////////////////////
-			ModelBarcodeObject* clone() const override;
+			ModelBarcodeObject* clone( QObject* parent = nullptr ) const override;
 
 
 			///////////////////////////////////////////////////////////////
@@ -121,6 +121,8 @@ namespace glabels
 			// Capability Implementations
 			///////////////////////////////////////////////////////////////
 		public:
+			bool fixedAspectRatio() const override;
+			bool fixedSize() const override;
 
 
 			///////////////////////////////////////////////////////////////
@@ -130,6 +132,13 @@ namespace glabels
 			void drawShadow( QPainter* painter, bool inEditor, merge::Record* record ) const override;
 			void drawObject( QPainter* painter, bool inEditor, merge::Record* record ) const override;
 			QPainterPath hoverPath( double scale ) const override;
+
+
+			///////////////////////////////////////////////////////////////
+			// Slots
+			///////////////////////////////////////////////////////////////
+		public slots:
+			virtual void onMergeChanged();
 
 
 			///////////////////////////////////////////////////////////////

--- a/model/ModelBoxObject.cpp
+++ b/model/ModelBoxObject.cpp
@@ -41,7 +41,7 @@ namespace glabels
 		///
 		/// Constructor
 		///
-		ModelBoxObject::ModelBoxObject()
+		ModelBoxObject::ModelBoxObject( QObject* parent ) : ModelShapeObject(parent)
 		{
 			// empty
 		}
@@ -76,8 +76,8 @@ namespace glabels
 		///
 		/// Copy constructor
 		///
-		ModelBoxObject::ModelBoxObject( const ModelBoxObject* object )
-			: ModelShapeObject( object )
+		ModelBoxObject::ModelBoxObject( const ModelBoxObject* object, QObject* parent )
+			: ModelShapeObject( object, parent )
 		{
 			// empty
 		}
@@ -95,9 +95,9 @@ namespace glabels
 		///
 		/// Clone
 		///
-		ModelBoxObject* ModelBoxObject::clone() const
+		ModelBoxObject* ModelBoxObject::clone( QObject* parent ) const
 		{
-			return new ModelBoxObject( this );
+			return new ModelBoxObject( this, parent );
 		}
 
 

--- a/model/ModelBoxObject.h
+++ b/model/ModelBoxObject.h
@@ -41,7 +41,7 @@ namespace glabels
 			// Lifecycle Methods
 			///////////////////////////////////////////////////////////////
 		public:
-			ModelBoxObject();
+			ModelBoxObject( QObject* parent = nullptr );
 
 			ModelBoxObject( const Distance&  x0,
 			                const Distance&  y0,
@@ -58,7 +58,7 @@ namespace glabels
 			                double           shadowOpacity = 1.0,
 			                const ColorNode& shadowColorNode = ColorNode() );
 
-			ModelBoxObject( const ModelBoxObject* object );
+			ModelBoxObject( const ModelBoxObject* object, QObject* parent = nullptr );
 		
 			~ModelBoxObject() override;
 
@@ -66,7 +66,7 @@ namespace glabels
 			///////////////////////////////////////////////////////////////
 			// Object duplication
 			///////////////////////////////////////////////////////////////
-			ModelBoxObject* clone() const override;
+			ModelBoxObject* clone( QObject* parent = nullptr ) const override;
 
 
 			///////////////////////////////////////////////////////////////

--- a/model/ModelEllipseObject.cpp
+++ b/model/ModelEllipseObject.cpp
@@ -41,7 +41,7 @@ namespace glabels
 		///
 		/// Constructor
 		///
-		ModelEllipseObject::ModelEllipseObject()
+		ModelEllipseObject::ModelEllipseObject( QObject* parent ) : ModelShapeObject(parent)
 		{
 			// empty
 		}
@@ -76,8 +76,8 @@ namespace glabels
 		///
 		/// Copy constructor
 		///
-		ModelEllipseObject::ModelEllipseObject( const ModelEllipseObject* object )
-			: ModelShapeObject( object )
+		ModelEllipseObject::ModelEllipseObject( const ModelEllipseObject* object, QObject* parent )
+			: ModelShapeObject( object, parent )
 		{
 			// empty
 		}
@@ -95,9 +95,9 @@ namespace glabels
 		///
 		/// Clone
 		///
-		ModelEllipseObject* ModelEllipseObject::clone() const
+		ModelEllipseObject* ModelEllipseObject::clone( QObject* parent ) const
 		{
-			return new ModelEllipseObject( this );
+			return new ModelEllipseObject( this, parent );
 		}
 
 

--- a/model/ModelEllipseObject.h
+++ b/model/ModelEllipseObject.h
@@ -41,7 +41,7 @@ namespace glabels
 			// Lifecycle Methods
 			///////////////////////////////////////////////////////////////
 		public:
-			ModelEllipseObject();
+			ModelEllipseObject( QObject* parent = nullptr );
 
 			ModelEllipseObject( const Distance&  x0,
 			                    const Distance&  y0,
@@ -58,7 +58,7 @@ namespace glabels
 			                    double           shadowOpacity = 1.0,
 			                    const ColorNode& shadowColorNode = ColorNode() );
 
-			ModelEllipseObject( const ModelEllipseObject* object );
+			ModelEllipseObject( const ModelEllipseObject* object, QObject* parent = nullptr );
 
 			~ModelEllipseObject() override;
 
@@ -66,7 +66,7 @@ namespace glabels
 			///////////////////////////////////////////////////////////////
 			// Object duplication
 			///////////////////////////////////////////////////////////////
-			ModelEllipseObject* clone() const override;
+			ModelEllipseObject* clone( QObject* parent = nullptr ) const override;
 
 
 			///////////////////////////////////////////////////////////////

--- a/model/ModelImageObject.cpp
+++ b/model/ModelImageObject.cpp
@@ -43,7 +43,7 @@ namespace glabels
 		///
 		/// Constructor
 		///
-		ModelImageObject::ModelImageObject() : mImage(nullptr), mSvgRenderer(nullptr)
+		ModelImageObject::ModelImageObject( QObject* parent ) : ModelObject(parent), mImage(nullptr), mSvgRenderer(nullptr)
 		{
 			mOutline = new Outline( this );
 
@@ -193,7 +193,7 @@ namespace glabels
 		///
 		/// Copy constructor
 		///
-		ModelImageObject::ModelImageObject( const ModelImageObject* object ) : ModelObject(object)
+		ModelImageObject::ModelImageObject( const ModelImageObject* object, QObject* parent ) : ModelObject(object, parent)
 		{
 			mFilenameNode = object->mFilenameNode;
 			if ( object->mImage )
@@ -243,9 +243,9 @@ namespace glabels
 		///
 		/// Clone
 		///
-		ModelImageObject* ModelImageObject::clone() const
+		ModelImageObject* ModelImageObject::clone( QObject* parent ) const
 		{
-			return new ModelImageObject( this );
+			return new ModelImageObject( this, parent );
 		}
 
 

--- a/model/ModelImageObject.h
+++ b/model/ModelImageObject.h
@@ -43,7 +43,7 @@ namespace glabels
 			// Lifecycle Methods
 			///////////////////////////////////////////////////////////////
 		public:
-			ModelImageObject();
+			ModelImageObject( QObject* parent = nullptr );
 
 			ModelImageObject( const Distance&  x0,
 			                  const Distance&  y0,
@@ -86,7 +86,7 @@ namespace glabels
 			                  double            shadowOpacity = 1.0,
 			                  const ColorNode&  shadowColorNode = ColorNode() );
 
-			ModelImageObject( const ModelImageObject* object );
+			ModelImageObject( const ModelImageObject* object, QObject* parent = nullptr );
 		
 			~ModelImageObject() override;
 
@@ -94,7 +94,7 @@ namespace glabels
 			///////////////////////////////////////////////////////////////
 			// Object duplication
 			///////////////////////////////////////////////////////////////
-			ModelImageObject* clone() const override;
+			ModelImageObject* clone( QObject* parent = nullptr ) const override;
 
 
 			///////////////////////////////////////////////////////////////

--- a/model/ModelLineObject.cpp
+++ b/model/ModelLineObject.cpp
@@ -41,7 +41,7 @@ namespace glabels
 		///
 		/// Constructor
 		///
-		ModelLineObject::ModelLineObject()
+		ModelLineObject::ModelLineObject( QObject* parent ) : ModelObject(parent)
 		{
 			mOutline = nullptr;
 
@@ -91,8 +91,8 @@ namespace glabels
 		///
 		/// Copy constructor
 		///
-		ModelLineObject::ModelLineObject( const ModelLineObject* object )
-			: ModelObject(object)
+		ModelLineObject::ModelLineObject( const ModelLineObject* object, QObject* parent )
+			: ModelObject(object, parent)
 		{
 			mLineWidth       = object->mLineWidth;
 			mLineColorNode   = object->mLineColorNode;
@@ -104,6 +104,8 @@ namespace glabels
 		///
 		ModelLineObject::~ModelLineObject()
 		{
+			delete mOutline;
+
 			foreach( Handle* handle, mHandles )
 			{
 				delete handle;
@@ -115,9 +117,9 @@ namespace glabels
 		///
 		/// Clone
 		///
-		ModelLineObject* ModelLineObject::clone() const
+		ModelLineObject* ModelLineObject::clone( QObject* parent ) const
 		{
-			return new ModelLineObject( this );
+			return new ModelLineObject( this, parent );
 		}
 
 

--- a/model/ModelLineObject.h
+++ b/model/ModelLineObject.h
@@ -41,7 +41,7 @@ namespace glabels
 			// Lifecycle Methods
 			///////////////////////////////////////////////////////////////
 		public:
-			ModelLineObject();
+			ModelLineObject( QObject* parent = nullptr );
 
 			ModelLineObject( const Distance&  x0,
 			                 const Distance&  y0,
@@ -56,7 +56,7 @@ namespace glabels
 			                 double           shadowOpacity = 1.0,
 			                 const ColorNode& shadowColorNode = ColorNode() );
 
-			ModelLineObject( const ModelLineObject* object );
+			ModelLineObject( const ModelLineObject* object, QObject* parent = nullptr );
 		
 			~ModelLineObject() override;
 
@@ -64,7 +64,7 @@ namespace glabels
 			///////////////////////////////////////////////////////////////
 			// Object duplication
 			///////////////////////////////////////////////////////////////
-			ModelLineObject* clone() const override;
+			ModelLineObject* clone( QObject* parent = nullptr ) const override;
 
 
 			///////////////////////////////////////////////////////////////

--- a/model/ModelObject.cpp
+++ b/model/ModelObject.cpp
@@ -43,7 +43,7 @@ namespace glabels
 		///
 		/// Constructor
 		///
-		ModelObject::ModelObject() : QObject(nullptr)
+		ModelObject::ModelObject( QObject* parent ) : QObject(parent)
 		{
 			mId = msNextId++;
 
@@ -105,7 +105,7 @@ namespace glabels
 		///
 		/// Copy constructor
 		///
-		ModelObject::ModelObject( const ModelObject* object )
+		ModelObject::ModelObject( const ModelObject* object, QObject* parent ) : QObject(parent)
 		{
 			mId = msNextId++;
 
@@ -971,6 +971,26 @@ namespace glabels
 
 
 		///
+		/// Virtual Fixed Aspect Ratio Capability Read-Only Property Default Getter
+		/// (Overridden by concrete class)
+		///
+		bool ModelObject::fixedAspectRatio() const
+		{
+			return false;
+		}
+
+
+		///
+		/// Virtual Fixed Size Capability Read-Only Property Default Getter
+		/// (Overridden by concrete class)
+		///
+		bool ModelObject::fixedSize() const
+		{
+			return false;
+		}
+
+
+		///
 		/// Set Absolute Position
 		///
 		void ModelObject::setPosition( const Distance& x0,
@@ -1044,17 +1064,20 @@ namespace glabels
 		void ModelObject::setSizeHonorAspect( const Distance& w,
 		                                      const Distance& h )
 		{
-			double aspectRatio = mH / mW;
+			double aspectRatio = mW != 0 ? mH / mW : 0;
 			Distance wNew = w;
 			Distance hNew = h;
 		
-			if ( h > (w*aspectRatio) )
+			if ( aspectRatio )
 			{
-				hNew = w*aspectRatio;
-			}
-			else
-			{
-				wNew = h/aspectRatio;
+				if ( h > (w*aspectRatio) )
+				{
+					hNew = w*aspectRatio;
+				}
+				else
+				{
+					wNew = h/aspectRatio;
+				}
 			}
 
 			setSize( wNew, hNew );
@@ -1066,8 +1089,8 @@ namespace glabels
 		///
 		void ModelObject::setWHonorAspect( const Distance& w )
 		{
-			double aspectRatio = mH / mW;
-			Distance h = w * aspectRatio;
+			double aspectRatio = mW != 0 ? mH / mW : 0;
+			Distance h = aspectRatio ? w * aspectRatio : mH;
 
 			if ( ( mW != w ) || ( mH != h ) )
 			{
@@ -1085,8 +1108,8 @@ namespace glabels
 		///
 		void ModelObject::setHHonorAspect( const Distance& h )
 		{
-			double aspectRatio = mH / mW;
-			Distance w = h / aspectRatio;
+			double aspectRatio = mW != 0 ? mH / mW : 0;
+			Distance w = aspectRatio ? h / aspectRatio : mW;
 
 			if ( ( mW != w ) || ( mH != h ) )
 			{
@@ -1275,6 +1298,15 @@ namespace glabels
 		/// Default sizeUpdated implementation.
 		///
 		void ModelObject::sizeUpdated()
+		{
+			// empty
+		}
+
+
+		///
+		/// Default onMergeChanged implementation.
+		///
+		void ModelObject::onMergeChanged()
 		{
 			// empty
 		}

--- a/model/ModelObject.h
+++ b/model/ModelObject.h
@@ -58,7 +58,7 @@ namespace glabels
 			// Lifecycle Methods
 			///////////////////////////////////////////////////////////////
 		protected:
-			ModelObject();
+			ModelObject( QObject* parent = nullptr );
 		
 			ModelObject( const Distance&  x0,
 			             const Distance&  y0,
@@ -72,7 +72,7 @@ namespace glabels
 			             double           shadowOpacity = 1.0,
 			             const ColorNode& shadowColorNode = ColorNode() );
 		
-			ModelObject( const ModelObject* object );
+			ModelObject( const ModelObject* object, QObject* parent = nullptr );
 		
 		public:
 			~ModelObject() override;
@@ -81,7 +81,7 @@ namespace glabels
 			///////////////////////////////////////////////////////////////
 			// Object duplication
 			///////////////////////////////////////////////////////////////
-			virtual ModelObject* clone() const = 0;
+			virtual ModelObject* clone( QObject* parent = nullptr ) const = 0;
 
 	
 			///////////////////////////////////////////////////////////////
@@ -386,6 +386,9 @@ namespace glabels
 			virtual bool canLineColor() const;
 			virtual bool canLineWidth() const;
 
+			virtual bool fixedAspectRatio() const;
+			virtual bool fixedSize() const;
+
 
 			///////////////////////////////////////////////////////////////
 			// Position and Size methods
@@ -442,6 +445,13 @@ namespace glabels
 
 			QList<Handle*>    mHandles;
 			Outline*          mOutline;
+
+
+			/////////////////////////////////
+			// Slots
+			/////////////////////////////////
+		public slots:
+			virtual void onMergeChanged();
 
 
 			///////////////////////////////////////////////////////////////

--- a/model/ModelShapeObject.cpp
+++ b/model/ModelShapeObject.cpp
@@ -32,7 +32,7 @@ namespace glabels
 		///
 		/// Constructor
 		///
-		ModelShapeObject::ModelShapeObject()
+		ModelShapeObject::ModelShapeObject( QObject* parent ) : ModelObject(parent)
 		{
 			mOutline = new Outline( this );
 
@@ -92,7 +92,7 @@ namespace glabels
 		///
 		/// Copy constructor
 		///
-		ModelShapeObject::ModelShapeObject( const ModelShapeObject* object ) : ModelObject(object)
+		ModelShapeObject::ModelShapeObject( const ModelShapeObject* object, QObject* parent ) : ModelObject(object, parent)
 		{
 			mLineWidth       = object->mLineWidth;
 			mLineColorNode   = object->mLineColorNode;

--- a/model/ModelShapeObject.h
+++ b/model/ModelShapeObject.h
@@ -41,7 +41,7 @@ namespace glabels
 			// Lifecycle Methods
 			///////////////////////////////////////////////////////////////
 		protected:
-			ModelShapeObject();
+			ModelShapeObject( QObject* parent = nullptr );
 
 			ModelShapeObject( const Distance&  x0,
 			                  const Distance&  y0,
@@ -58,7 +58,7 @@ namespace glabels
 			                  double           shadowOpacity,
 			                  const ColorNode& shadowColorNode );
 
-			ModelShapeObject( const ModelShapeObject* object );
+			ModelShapeObject( const ModelShapeObject* object, QObject* parent = nullptr );
 		public:
 			~ModelShapeObject() override;
 

--- a/model/ModelTextObject.cpp
+++ b/model/ModelTextObject.cpp
@@ -47,7 +47,7 @@ namespace glabels
 		///
 		/// Constructor
 		///
-		ModelTextObject::ModelTextObject()
+		ModelTextObject::ModelTextObject( QObject* parent ) : ModelObject(parent)
 		{
 			mOutline = new Outline( this );
 
@@ -136,8 +136,8 @@ namespace glabels
 		///
 		/// Copy constructor
 		///
-		ModelTextObject::ModelTextObject( const ModelTextObject* object )
-			: ModelObject(object)
+		ModelTextObject::ModelTextObject( const ModelTextObject* object, QObject* parent )
+			: ModelObject(object, parent)
 		{
 			mText              = object->mText;
 			mFontFamily        = object->mFontFamily;
@@ -174,9 +174,9 @@ namespace glabels
 		///
 		/// Clone
 		///
-		ModelTextObject* ModelTextObject::clone() const
+		ModelTextObject* ModelTextObject::clone( QObject* parent ) const
 		{
-			return new ModelTextObject( this );
+			return new ModelTextObject( this, parent );
 		}
 
 

--- a/model/ModelTextObject.h
+++ b/model/ModelTextObject.h
@@ -44,7 +44,7 @@ namespace glabels
 			// Lifecycle Methods
 			///////////////////////////////////////////////////////////////
 		public:
-			ModelTextObject();
+			ModelTextObject( QObject* parent = nullptr );
 		
 			ModelTextObject( const Distance&       x0,
 			                 const Distance&       y0,
@@ -70,7 +70,7 @@ namespace glabels
 			                 double                shadowOpacity = 1.0,
 			                 const ColorNode&      shadowColorNode = ColorNode() );
 
-			ModelTextObject( const ModelTextObject* object );
+			ModelTextObject( const ModelTextObject* object, QObject* parent = nullptr );
 		
 			~ModelTextObject() override;
 
@@ -78,7 +78,7 @@ namespace glabels
 			///////////////////////////////////////////////////////////////
 			// Object duplication
 			///////////////////////////////////////////////////////////////
-			ModelTextObject* clone() const override;
+			ModelTextObject* clone( QObject* parent = nullptr ) const override;
 
 
 			///////////////////////////////////////////////////////////////

--- a/model/RawText.cpp
+++ b/model/RawText.cpp
@@ -87,6 +87,33 @@ namespace glabels
 
 
 		///
+		/// Expand all place holders using sample string if not in record
+		///
+		QString RawText::expandSample( const QString& sample, merge::Record* record ) const
+		{
+			merge::Record emptyRecord;
+
+			if ( !record )
+			{
+				record = &emptyRecord;
+			}
+
+			foreach ( const Token& token, mTokens )
+			{
+				if ( token.isField )
+				{
+					if ( !record->contains( token.field.fieldName() ) )
+					{
+						(*record)[token.field.fieldName()] = sample;
+					}
+				}
+			}
+
+			return expand( record );
+		}
+
+
+		///
 		/// Does raw text contain place holders?
 		///
 		bool RawText::hasPlaceHolders() const

--- a/model/RawText.h
+++ b/model/RawText.h
@@ -53,6 +53,7 @@ namespace glabels
 			QString toString() const;
 			std::string toStdString() const;
 			QString expand( merge::Record* record ) const;
+			QString expandSample( const QString& sample, merge::Record* record = nullptr ) const;
 			bool hasPlaceHolders() const;
 			bool isEmpty() const;
 

--- a/model/unit_tests/CMakeLists.txt
+++ b/model/unit_tests/CMakeLists.txt
@@ -25,6 +25,14 @@ if (Qt5Test_FOUND)
   add_test (NAME XmlLabel COMMAND TestXmlLabel)
 
   #=======================================
+  # Test Barcode classes
+  #=======================================
+  qt5_wrap_cpp (TestBarcode_moc_sources TestBarcode.h)
+  add_executable (TestBarcode TestBarcode.cpp ${TestBarcode_moc_sources})
+  target_link_libraries (TestBarcode Model Qt5::Test)
+  add_test (NAME Barcode COMMAND TestBarcode)
+
+  #=======================================
   # Test ColorNode class
   #=======================================
   qt5_wrap_cpp (TestColorNode_moc_sources TestColorNode.h)
@@ -47,6 +55,54 @@ if (Qt5Test_FOUND)
   add_executable (TestModel TestModel.cpp ${TestModel_moc_sources})
   target_link_libraries (TestModel Model Qt5::Test)
   add_test (NAME Model COMMAND TestModel)
+
+  #=======================================
+  # Test ModelBarcodeObject class
+  #=======================================
+  qt5_wrap_cpp (TestModelBarcodeObject_moc_sources TestModelBarcodeObject.h)
+  add_executable (TestModelBarcodeObject TestModelBarcodeObject.cpp ${TestModelBarcodeObject_moc_sources})
+  target_link_libraries (TestModelBarcodeObject Model Qt5::Test)
+  add_test (NAME ModelBarcodeObject COMMAND TestModelBarcodeObject)
+
+  #=======================================
+  # Test ModelBoxObject class
+  #=======================================
+  qt5_wrap_cpp (TestModelBoxObject_moc_sources TestModelBoxObject.h)
+  add_executable (TestModelBoxObject TestModelBoxObject.cpp ${TestModelBoxObject_moc_sources})
+  target_link_libraries (TestModelBoxObject Model Qt5::Test)
+  add_test (NAME ModelBoxObject COMMAND TestModelBoxObject)
+
+  #=======================================
+  # Test ModelEllipseObject class
+  #=======================================
+  qt5_wrap_cpp (TestModelEllipseObject_moc_sources TestModelEllipseObject.h)
+  add_executable (TestModelEllipseObject TestModelEllipseObject.cpp ${TestModelEllipseObject_moc_sources})
+  target_link_libraries (TestModelEllipseObject Model Qt5::Test)
+  add_test (NAME ModelEllipseObject COMMAND TestModelEllipseObject)
+
+  #=======================================
+  # Test ModelImageObject class
+  #=======================================
+  qt5_wrap_cpp (TestModelImageObject_moc_sources TestModelImageObject.h)
+  add_executable (TestModelImageObject TestModelImageObject.cpp ${TestModelImageObject_moc_sources})
+  target_link_libraries (TestModelImageObject Model Qt5::Test)
+  add_test (NAME ModelImageObject COMMAND TestModelImageObject)
+
+  #=======================================
+  # Test ModelLineObject class
+  #=======================================
+  qt5_wrap_cpp (TestModelLineObject_moc_sources TestModelLineObject.h)
+  add_executable (TestModelLineObject TestModelLineObject.cpp ${TestModelLineObject_moc_sources})
+  target_link_libraries (TestModelLineObject Model Qt5::Test)
+  add_test (NAME ModelLineObject COMMAND TestModelLineObject)
+
+  #=======================================
+  # Test ModelTextObject class
+  #=======================================
+  qt5_wrap_cpp (TestModelTextObject_moc_sources TestModelTextObject.h)
+  add_executable (TestModelTextObject TestModelTextObject.cpp ${TestModelTextObject_moc_sources})
+  target_link_libraries (TestModelTextObject Model Qt5::Test)
+  add_test (NAME ModelTextObject COMMAND TestModelTextObject)
 
   #=======================================
   # Test RawText class

--- a/model/unit_tests/TestModel.cpp
+++ b/model/unit_tests/TestModel.cpp
@@ -343,6 +343,7 @@ void TestModel::saveRestore()
 	QVERIFY( model->isModified() );
 	QCOMPARE( model->objectList().size(), 1 );
 	QCOMPARE( model->objectList().first(), object1 );
+	QCOMPARE( model->objectList().first()->parent(), model );
 
 	model->clearModified();
 	QVERIFY( !model->isModified() );
@@ -352,6 +353,7 @@ void TestModel::saveRestore()
 	QVERIFY( model->isModified() );
 	QCOMPARE( model->objectList().size(), 2 );
 	QCOMPARE( model->objectList().last(), object2 );
+	QCOMPARE( model->objectList().last()->parent(), model );
 
 	QString modelShortName = model->shortName(); // If no fileName set then model expects to have have this called before being saved/restored (otherwise get differing untitled names)
 
@@ -369,6 +371,10 @@ void TestModel::saveRestore()
 	QCOMPARE( saved->objectList().size(), model->objectList().size() );
 	QVERIFY( saved->objectList().at(0) != object1 ); // Objects copied
 	QVERIFY( saved->objectList().at(1) != object2 ); // Objects copied
+	QCOMPARE( saved->objectList().at(0)->parent(), saved );
+	QCOMPARE( saved->objectList().at(1)->parent(), saved );
+	QVERIFY( saved->objectList().at(0)->parent() != model->objectList().at(0)->parent() );
+	QVERIFY( saved->objectList().at(1)->parent() != model->objectList().at(1)->parent() );
 	QCOMPARE( saved->objectList().at(0)->x0(), model->objectList().at(0)->x0() );
 	QCOMPARE( saved->objectList().at(0)->y0(), model->objectList().at(0)->y0() );
 	QCOMPARE( saved->objectList().at(1)->x0(), model->objectList().at(1)->x0() );
@@ -419,8 +425,10 @@ void TestModel::saveRestore()
 	QVERIFY( model->w() != saved->w() );
 	QVERIFY( model->h() != saved->h() );
 	QVERIFY( model->objectList().size() != saved->objectList().size() );
+	QVERIFY( model->objectList().at(0)->parent() != saved->objectList().at(0)->parent() );
 	QVERIFY( model->objectList().at(0)->x0() != saved->objectList().at(0)->x0() );
 	QVERIFY( model->objectList().at(0)->y0() != saved->objectList().at(0)->y0() );
+	QVERIFY( model->objectList().at(0)->parent() != saved->objectList().at(1)->parent() );
 	QCOMPARE( model->objectList().at(0)->x0(), saved->objectList().at(1)->x0() ); // Unchanged
 	QVERIFY( model->objectList().at(0)->y0() != saved->objectList().at(1)->y0() );
 
@@ -435,6 +443,8 @@ void TestModel::saveRestore()
 	QCOMPARE( model->h(), saved->h() );
 	QCOMPARE( model->objectList().size(), saved->objectList().size() );
 	QCOMPARE( model->objectList().size(), 2 );
+	QCOMPARE( model->objectList().at(0)->parent(), model );
+	QCOMPARE( model->objectList().at(1)->parent(), model );
 	QCOMPARE( model->objectList().at(0)->x0(), saved->objectList().at(0)->x0() );
 	QCOMPARE( model->objectList().at(0)->y0(), saved->objectList().at(0)->y0() );
 	QCOMPARE( model->objectList().at(1)->x0(), saved->objectList().at(1)->x0() );
@@ -454,6 +464,8 @@ void TestModel::saveRestore()
 	QVERIFY( model->h() != saved->h() );
 	QCOMPARE( model->objectList().size(), 1 );
 	QVERIFY( model->objectList().size() != saved->objectList().size() );
+	QCOMPARE( model->objectList().at(0)->parent(), model );
+	QVERIFY( model->objectList().at(0)->parent() != saved->objectList().at(0)->parent() );
 	QVERIFY( model->objectList().at(0)->x0() != saved->objectList().at(0)->x0() );
 	QVERIFY( model->objectList().at(0)->y0() != saved->objectList().at(0)->y0() );
 	QCOMPARE( model->merge(), merge2 ); // Same

--- a/model/unit_tests/TestRawText.cpp
+++ b/model/unit_tests/TestRawText.cpp
@@ -91,4 +91,18 @@ void TestRawText::rawText()
 	rawText = "${key2}${key3}${key1}";
 	QVERIFY( rawText.hasPlaceHolders() );
 	QCOMPARE( rawText.expand( &record ), QString( "val2val1" ) );
+
+	///
+	/// Sample Record
+	///
+	record["key3"] = "val3";
+
+	rawText = "${key0}";
+	QCOMPARE( rawText.expandSample( "1234567890", &record ), QString( "1234567890" ) );
+
+	rawText = "${key0}${key1}${key3}asdf${key4}${key2}${key3}";
+	QCOMPARE( rawText.expandSample( "1234567890", &record ), QString( "1234567890val1val3asdf1234567890val2val3" ) );
+
+	rawText = "asdf";
+	QCOMPARE( rawText.expandSample( "1234567890", &record ), QString( "asdf" ) );
 }

--- a/model/unit_tests/TestXmlLabel.cpp
+++ b/model/unit_tests/TestXmlLabel.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "TestXmlLabel.h"
+#include "Test_Constants.h"
 
 #include "model/XmlLabelCreator.h"
 #include "model/XmlLabelParser.h"
@@ -72,8 +73,9 @@ void TestXmlLabel::serializeDeserialize()
 	bool lock = true, noLock = false, shadow = true, noShadow = false;
 	ColorNode black( Qt::black ), white( Qt::white ), red( Qt::red ), green( Qt::green ), blue( Qt::blue );
 	QMatrix tMatrix( 1, 0, 0, 1, 50.0, 50.0 ), sMatrix( 0.5, 0, 0, 1.0, 0, 0 );
-	QImage png( QFINDTESTDATA( "../../../glabels/images/glabels-logo.png" ) );
-	QByteArray svg = "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" width=\"16\" height=\"16\" ><path d=\"M 3,4 l 5.5,11 -4,-2 v 5 h -3 v -5 l -4,2 Z\" /></svg>";
+	QImage png;
+	QVERIFY( png.loadFromData( QByteArray::fromBase64( glabels::test::blue_8x8_png ), "PNG" ) );
+	QByteArray svg = glabels::test::red_8x8_svg;
 	Style bcStyle = Backends::defaultStyle();
 
 	objects << new ModelBoxObject( 0, 1, 10, 20, lock, 2, red, green, tMatrix, shadow, 1, 2, 0.7, black );

--- a/translations/glabels_C.ts
+++ b/translations/glabels_C.ts
@@ -1146,6 +1146,13 @@
     </message>
 </context>
 <context>
+    <name>glabels::BarcodeMenuButton</name>
+    <message>
+        <source>%1 - %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>glabels::ColorPaletteDialog</name>
     <message>
         <source>Custom color...</source>
@@ -2227,10 +2234,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>IEC16022 (DataMatrix)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>EAN (any)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2316,10 +2319,6 @@
     </message>
     <message>
         <source>Code 93</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>IEC18004 (QRCode)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2544,6 +2543,14 @@
     </message>
     <message>
         <source>UK Plessey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Data Matrix (IEC16022)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QR Code (IEC18004)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
- checks backendId on Style equality; new properties fixedAspectRatio and fixedSize
- uses new fixed properties in ModelBarcodeObject to adjust Position interface
- various changes to barcode style properties on registering
- adds menu checks to BarcodeMenu to indicate active selection
- sets BarcodeMenuButton with backend text as well
- uses library encode in GnuBarcode and Zint to validate
- uses option_2 to set checksum for Zint and sets input_mode to unicode
- sets w/h to render width/height in Zint vectorize
- set MIN_CELL_SIZE to 1 in Barcode2dBase (previously quite large)
- checks internal Data Matrix input is ISO-8859-1
- uses MIN_POINT_SIZE when setting setPointSizeF (seems to be QFontMetricsF bug)
- adds sampleRecord to Merge to give better feedback for barcodes with merge data
- adds parent to the default/copy constructor and clone of ModelObjects, for use in Model
- check for divide by 0 in setSize/W/H/HonorAspect
- adds expandSample to RawText
- adds unit tests for ModelObjects and Barcode, and for RawText & Merge changes

The main symptom of not checking the `backendId` on `Style` equality was that selecting a barcode with the same name in external libraries wouldn't change the object.

The reason for adding `parent` to the various `ModelObject`s copy constructors/clones is so that when used in `Model` `addObject()` and `clone()` it's immediately set correctly - this enables `ModelBarcode::update()` to get the model via `parent()` so it can expand the sample record.

The reason for adding the sample record stuff is to give better feedback when using merge data with barcodes.