### PR TITLE
Relax code39 barcode minimum size requirements

### DIFF
--- a/glbarcode/BarcodeCode39.cpp
+++ b/glbarcode/BarcodeCode39.cpp
@@ -85,14 +85,14 @@ namespace
 	const std::string frameSymbol = "NwNnWnWnN";
 
 	/* Vectorization constants */
-	const double MIN_X       = ( 0.01 *  PTS_PER_INCH );
+	const double MIN_X       = ( 0.0075 *  PTS_PER_INCH );
 	const double N           = 2.5;
 	const double MIN_I       = MIN_X;
-	const double MIN_HEIGHT  = ( 0.25 *  PTS_PER_INCH );
-	const double MIN_QUIET   = ( 0.10 *  PTS_PER_INCH );
+	const double MIN_HEIGHT  = ( 0.19685 *  PTS_PER_INCH );
+	const double MIN_QUIET   = ( 10 * MIN_X );
 
-	const double MIN_TEXT_AREA_HEIGHT = 14.0;
-	const double MIN_TEXT_SIZE        = 10.0;
+	const double MIN_TEXT_AREA_HEIGHT = 12.0;
+	const double MIN_TEXT_SIZE        = 8.0;
 
 }
 


### PR DESCRIPTION
- Most libraries use the 7.5 mils for the minimum X value, not 10.
- Minimum recommended barcode height is 5 mm according to ISO/IEC 16388.
- Minimum quiet zone is 10 * X according to ISO/IEC 16388.
- Adjust minimum text sizes for reduced minimum barcode sizes

Signed-off-by: Marton Balint <cus@passwd.hu>