### PR TITLE
Display newlines in merge view

### DIFF
--- a/glabels/MergeView.cpp
+++ b/glabels/MergeView.cpp
@@ -31,6 +31,7 @@
 
 namespace glabels
 {
+	const QChar NEWLINE_CHAR = QChar(0x23CE);
 
 	///
 	/// Constructor
@@ -283,7 +284,9 @@ namespace glabels
 			auto* item = new QTableWidgetItem();
 			if ( record->contains( mPrimaryKey ) )
 			{
-				item->setText( (*record)[mPrimaryKey] );
+				QString text = (*record)[mPrimaryKey];
+				text.replace('\n', NEWLINE_CHAR);
+				item->setText( text );
 			}
 			item->setFlags( Qt::ItemIsEnabled | Qt::ItemIsUserCheckable );
 			item->setCheckState( record->isSelected() ? Qt::Checked : Qt::Unchecked );
@@ -298,7 +301,9 @@ namespace glabels
 				{
 					if ( record->contains( key ) )
 					{
-						auto* item = new QTableWidgetItem( (*record)[key] );
+						QString text = (*record)[key];
+						text.replace('\n', NEWLINE_CHAR);
+						auto* item = new QTableWidgetItem( text );
 						item->setFlags( Qt::ItemIsEnabled );
 						recordsTable->setItem( iRow, iCol, item );
 						recordsTable->resizeColumnToContents( iCol );

--- a/glabels/MergeView.cpp
+++ b/glabels/MergeView.cpp
@@ -284,8 +284,7 @@ namespace glabels
 			auto* item = new QTableWidgetItem();
 			if ( record->contains( mPrimaryKey ) )
 			{
-				QString text = (*record)[mPrimaryKey];
-				text.replace('\n', NEWLINE_CHAR);
+				auto text = printableTextForView( (*record)[mPrimaryKey] );
 				item->setText( text );
 			}
 			item->setFlags( Qt::ItemIsEnabled | Qt::ItemIsUserCheckable );

--- a/glabels/MergeView.cpp
+++ b/glabels/MergeView.cpp
@@ -301,8 +301,7 @@ namespace glabels
 				{
 					if ( record->contains( key ) )
 					{
-						QString text = (*record)[key];
-						text.replace('\n', NEWLINE_CHAR);
+						auto text = printableTextForView( (*record)[key] );
 						auto* item = new QTableWidgetItem( text );
 						item->setFlags( Qt::ItemIsEnabled );
 						recordsTable->setItem( iRow, iCol, item );
@@ -324,4 +323,18 @@ namespace glabels
 		mBlock = false;
 	}
 
+
+	///
+	/// modify text to be printable e.g. replace newlines
+	///
+	QString MergeView::printableTextForView( QString text )
+	{
+		// Replace windows style newlines
+		text.replace("\r\n", NEWLINE_CHAR);
+
+		// Replace unix style newlines
+		text.replace("\n", NEWLINE_CHAR);
+
+		return text;
+	}
 } // namespace glabels

--- a/glabels/MergeView.h
+++ b/glabels/MergeView.h
@@ -79,6 +79,7 @@ namespace glabels
 	private:
 		void loadHeaders( merge::Merge* merge );
 		void loadTable( merge::Merge* merge );
+		static QString printableTextForView( QString text );
 
 
 		/////////////////////////////////


### PR DESCRIPTION
Hello,
while using the most recent version of your software got some problems showing the full content of the entries in the merge view. During some investigation i found out that only the first line of an entry gets printed out in this version and the rest is replaced by `...`. With my changes here all newline control characters will be printed as unicode char `⏎`.

Example:
![image](https://user-images.githubusercontent.com/11859624/103410114-22f48980-4b6a-11eb-992e-c6811858293f.png)


I hope you like this