### PR TITLE
add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ TEST-DATA
 SAV*
 OLD*
 
+#
+# Ignore nix related stuff
+#
+result**

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1619345332,
+        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1620149228,
+        "narHash": "sha256-mM077nj/VAYZWAPQCMVH0GvBSdm/JYuP/xiEkJfUdYw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8f83860a0ae969c5fd19ec3104b9063f142a97bd",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "Development version of the next major version of gLabels";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+  flake-utils.lib.eachDefaultSystem (system:
+  let pkgs = nixpkgs.legacyPackages.${system}; in
+  rec {
+    packages.glabels-qt = pkgs.qt5.mkDerivation {
+      name = "glabels-qt";
+      src = ./.;
+      nativeBuildInputs = with pkgs; [ cmake ];
+      buildInputs = with pkgs; [ qt5.qttools zlib ];
+    };
+    defaultPackage = packages.glabels-qt;
+    apps.glabels-qt = flake-utils.lib.mkApp { drv = packages.glabels-qt; };
+    defaultApp = apps.glabels-qt;
+  });
+}


### PR DESCRIPTION
I added a nix flake file for this. It enables any user to compile and run glabels-qt with no other dependencies then a recent `nix`. To run the current master for example, a user would just have to call `nix run github:jimevins/glabels-qt`. As the dependencies are pinpointed in the `flake.lock` file, it would make sense to update it semi-regularly (every couple of months). Would this be a welcome addition to the project?