### PR TITLE
Update BUILD-INSTRUCTIONS-MACOS.md

### DIFF
--- a/docs/BUILD-INSTRUCTIONS-MACOS.md
+++ b/docs/BUILD-INSTRUCTIONS-MACOS.md
@@ -3,10 +3,20 @@ gLabels MacOS Build Instructions
 
 ## Prerequisites
 
+For Intel Macs
 ```
 brew install cmake
 brew install qt
 ```
+
+For Apple Silcon Macs
+```
+brew install gcc
+brew install cmake
+brew install qt5
+```
+
+
 
 ## Compile and Install
 
@@ -14,7 +24,13 @@ brew install qt
 cd <i>glabels_source_directory</i>
 mkdir build
 cd build
+
+# For Intel Macs
 cmake -D CMAKE_PREFIX_PATH=/usr/local/opt/qt  ..
+
+# For Apple Silcon Macs
+cmake -D CMAKE_PREFIX_PATH="/opt/homebrew/opt/qt5" -DCMAKE_C_COMPILER=/opt/homebrew/bin/gcc-11 -DCMAKE_CXX_COMPILER=/opt/homebrew/bin/g++-11  ..
+
 make
 sudo make install
 </pre>


### PR DESCRIPTION
Build instructions are not working for (at least) the new Silicon mac's. I don't have access to an older intel mac to see if the instructions are still working there, but since I couldn't find any open issues regarding this I assume it's only affecting silicon macs.