### PR TITLE
Brother P-Touch TZe templates 

### DIFF
--- a/templates/brother-other-templates.xml
+++ b/templates/brother-other-templates.xml
@@ -85,12 +85,6 @@
    May fit to another Brother PT printers, using replaceable laminated thermal cassetes.
    All labels are configured as continuous
       
-   REFERENCES:
-      
-      Brother Industries, Ltd. (October 3, 2011), "Brother PT Series
-      Command Reference (QL-500/550/560/570/580N/650TD/700/1050/1060N)",
-      http://download.brother.com/welcome/docp000678/cv_qlseries_eng_raster_600.pdf
-      
    *********************************************************************
    *********************************************************************
   -->


### PR DESCRIPTION
I am using glabels for printing on PTouch label printers and thus added missing templates for P-Touch printers using replaceable laminated thermal labels.

Contains templates for various label sizes available for P-Touch printing> 6mm / 9mm / 12m / 18mm / 24mm / 36mm.

Tested on Brother P-Touch P700. As the cassetes are universal, these templates will prbably work with various P-Touch models