### PR TITLE
Update Fedora build example

### DIFF
--- a/docs/BUILD-INSTRUCTIONS-LINUX.md
+++ b/docs/BUILD-INSTRUCTIONS-LINUX.md
@@ -90,7 +90,7 @@ $ sudo make install
 We assume the build system already has things like cmake and the GNU C++ suite installed.
 
 ```
-$ sudo dnf install qt6-qtbase-devel qt6-qtsvg-devel qt6-linguist  qt6-qttools-devel
+$ sudo dnf install qt6-qtbase-devel qt6-qtsvg-devel qt6-linguist qt6-qttools-devel
 ```
 These installs will pull in additional packages to fill out their prerequisites.
 Fedora has a different package naming scheme than Ubuntu. This is to distinguish the QT6


### PR DESCRIPTION
Update build example to use Fedora 42, since 35 has been eol for a few years. This should be more in line with what folks are using currently.