### PR TITLE
Add instructions to compile on MacOS AMD64 and ARM64

### DIFF
--- a/docs/BUILD-INSTRUCTIONS-MACOS.md
+++ b/docs/BUILD-INSTRUCTIONS-MACOS.md
@@ -2,10 +2,16 @@ gLabels MacOS Build Instructions
 ================================
 
 ## Prerequisites
-
 ```
 brew install cmake
 brew install qt@6
+```
+
+## Optional dependencies
+```
+brew install zlib
+brew install qrencode
+brew install zint
 ```
 
 ## Compile and Install


### PR DESCRIPTION
Simplified instructions due to recent changes.
Solves #158 & #200

Closed #206 due to becoming stale