### PR TITLE
Fix problematic `git log` command usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ endif ()
   
 execute_process(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  COMMAND git log -1 --format=%h
+  COMMAND git show-ref --head --hash --abbrev head
   RESULT_VARIABLE COMMIT_HASH_VALID
   OUTPUT_VARIABLE COMMIT_HASH
   OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -56,7 +56,7 @@ endif ()
   
 execute_process(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  COMMAND git log -1 --format=%cd --date=short
+  COMMAND git rev-list -1 --no-commit-header --format=%cs HEAD
   RESULT_VARIABLE COMMIT_DATE_VALID
   OUTPUT_VARIABLE COMMIT_DATE
   OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
So if someone has the git option `log.showSignature` set to `true` in their global git config (just because they prefer that in the default output of `git log` in CLI), the build will fail, because this is what will get written to `Version.h`:

```cpp
                        const QString STRING  = "3.99-master591";
                        const QString LONG_STRING  = "3.99-master591 (gpg: Signature made wto, 11 lis 2025, 02:12:36 CET
gpg:                using RSA key B5690EEEBB952194
gpg: Good signature from "GitHub <noreply@github.com>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 9684 79A1 AFF9 27E3 7D1A  566B B569 0EEE BB95 2194
21343d4 gpg: Signature made wto, 11 lis 2025, 02:12:36 CET
gpg:                using RSA key B5690EEEBB952194
gpg: Good signature from "GitHub <noreply@github.com>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 9684 79A1 AFF9 27E3 7D1A  566B B569 0EEE BB95 2194
2025-11-10)";
```

So this PR switches the commands used to ones not affected by `log.*` config options. There are some softwares out there, apparently, that'd always do something like `git -c log.showSignature=false log ...` (among some other options; one of them being PyCharm from what I see), but I think that'd feel way uglier...

Also note that trying to override the git config option to false just in the local repo isn't an ideal workaround at all, because that wouldn't help with AUR helpers which expect to be able to cleanly build a freshly cloned repo etc. Surprisingly, after using this option for a very long time, this is the first and only breakage I've ever encountered actually. So it is a bug by all means.

P.S. Probably consider switching to `git describe` at some point for a "pretty version string", at least once git tags are in use