### PR TITLE
Downloadable CI artifacts from GitHub Actions

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -112,6 +112,7 @@ jobs:
       shell: bash
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+        echo "install-output-dir=${{ github.workspace }}/install" >> "$GITHUB_OUTPUT"
 
     - name: Configure CMake
       run: >
@@ -139,6 +140,19 @@ jobs:
       if: startsWith( matrix.os, 'macos-' )
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
       run: ctest --build-config ${{ matrix.build_type }}
+
+    - name: Install
+      run: >
+        cmake
+        --install ${{ steps.strings.outputs.build-output-dir }}
+        --config ${{ matrix.build_type }}
+        --prefix ${{ steps.strings.outputs.install-output-dir }}
+
+    - name: Upload install artifacts
+      uses: actions/upload-artifact@v5
+      with:
+        name: glabels-qt-${{ matrix.os }}-${{ matrix.c_compiler }}
+        path: ${{ steps.strings.outputs.install-output-dir }}
 
 #    - name: Tmate
 #      uses: mxschmitt/action-tmate@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # My cmake build directory
 /build
+/install
 
 # Compiled Object files
 *.slo

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ There are currently no official releases of gLabels 4.
 
 ### Continuous Integration Snapshots
 
-Currently there are no self-hosted binary snapshot releases available.  I plan to make these available again once 4.0 is more imminent.  In the mean time, I encourage you to try building the code yourself.
+Binary snapshots can be downloaded from [GitHub Actions CI workflow artifacts](https://github.com/j-evins/glabels-qt/actions/workflows/build-tests.yml) or from [nightly.link](https://nightly.link/j-evins/glabels-qt/workflows/build-tests/master) without a GitHub account.
 
 Some third-party packages may be available available:
 
 
 | Platform  | Files                                                                                | Notes                                                         |
 |:----------|:-------------------------------------------------------------------------------------|:--------------------------------------------------------------|
-| Archlinux | [Archlinux User Repository Page](https://aur.archlinux.org/packages/glabels-qt-git/) | Maintained by [Mario Blättermann](https://github.com/mariobl) |
+| Arch Linux | [Arch Linux User Repository Page](https://aur.archlinux.org/packages/glabels-qt-git/) | Maintained by [Mario Blättermann](https://github.com/mariobl) |
 | Ubuntu    | [PPA Page](https://code.launchpad.net/~krisives/+archive/ubuntu/glabels-qt)          | Maintained by [Kristopher Ives](https://github.com/krisives)  |
 
 


### PR DESCRIPTION
Added so that people can kind-of run it without building, will probably be the most useful for Windows users where I can imagine compiling stuff with Qt might be a pain.

Since you'll probably squash the PR if merging anyway, I won't bother force-pushing to correct the commit name from "test" to something more sensible (since the PR name will be the one to prevail)

Can see this at work here:

- https://github.com/p0358/glabels-qt/actions/runs/19868969095
- https://nightly.link/p0358/glabels-qt/workflows/build-tests/ci-artifacts
