### PR TITLE
Flatpak support

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,42 @@
+name: Flatpak build
+
+on:
+  push:
+
+jobs:
+  flatpak:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.10
+      options: --privileged
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+      # Don't fail the whole workflow if one architecture fails
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: 'recursive'
+
+      - name: Install deps
+        if: ${{ matrix.arch != 'x86_64' }}
+        run: |
+          # Use the static binaries because it's unable to use a package manager 
+          curl https://download.docker.com/linux/static/stable/x86_64/docker-26.0.0.tgz --output ./docker.tgz
+          tar xzvf docker.tgz
+          mv docker/* /usr/bin
+
+      - name: Set up QEMU
+        if: ${{ matrix.arch != 'x86_64' }}
+        id: qemu
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: glabels-qt-${{ matrix.arch }}.flatpak
+          manifest-path: org.glabels.glabels-qt.yml
+          cache-key: flatpak-builder-${{ matrix.arch }}-${{ github.sha }}
+          arch: ${{ matrix.arch }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,15 @@
 # My cmake build directory
 /build
+/install
+
+# Flatpak build directories
+/.flatpak-builder
+/.cache
+/repo
+/builddir
+
+# Flatpak packages
+*.flatpak
 
 # Compiled Object files
 *.slo

--- a/org.glabels.glabels-qt.yml
+++ b/org.glabels.glabels-qt.yml
@@ -1,0 +1,21 @@
+id: org.glabels.glabels-qt
+runtime: org.kde.Platform
+runtime-version: '6.10'
+sdk: org.kde.Sdk
+command: glabels-qt
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  - --socket=cups
+  - --filesystem=~/.glabels:ro
+modules:
+  - name: glabels-qt
+    buildsystem: cmake
+    sources:
+      - type: dir
+        path: .
+      #- type: git
+      #  url: https://github.com/j-evins/glabels-qt.git
+      #  tag: 3.99-master602


### PR DESCRIPTION
Since I realized pretty much minimal changes are required to get it to work. Most changes are improvements on top of that bare minimum (which was runnable only from the command line). But overall as far as file opening/saving and printing goes, it just works (thanks to Qt and CMake).

The changes are:

- legacy appinfo was migrated to the newer metainfo file format, with new fields added, in line with FlatHub's guidelines
- the files under data/ were renamed to the reverse domain notation convention. That's a requirement for FlatHub, so easier to do that rather than renaming them just on Flatpak build and risking bugs. That's a better convention anyway, plus I did the `QApplication::setDesktopFileName`, which ensures that the WM class name matches the .desktop file name, which the DEs do very much like for some things.
- also added some translations to both metainfo and desktop files (I dropped `media covers` fragment, since it's virtually non-translatable, plus the FlatHub recommendation is to keep summary up to 35 chars, which is very narrow, but overall 2 good reasons to drop it and move it to description text; this allowed to also re-use existing translations in correct grammatical form)
- CI workflow for generating exported `*.flatpak` package, this uses the .yml manifest that must be in repository's root folder; this is a separate .yml from what'd be used for FlatHub, but it'd be almost 1:1 the same, just replacing `dir` source with `git` that's currently commented out

Overall my strong motivation for contributing Flatpak support was that for some reason I get really nasty lags when running the app outside of the sandbox, which I'll have to create an issue for. Also the fact that it basically just works, and works nicely. Generally it seems the shape of glabels-qt is very good, this thing is already superior compared to the old GTK counterpart (that has a few pretty annoying fundamental bugs too). So I'm kinda rooting for some release soon!

I've designated `org.glabels.glabels-qt` as the ID, since you own the domain, and the last part is re-using the existing non-domain-notated identifier/app name. But the problem is that `https://glabels.org` doesn't respond, only http does. This fails appstream validation of the metainfo, which isn't a problem for our local builds, but it'd be a no-go for Flathub. So I'd ask you to please fix it. I see this is some kind of hosting IP doing the redirects. If it's some kind of VPS and you don't want to be bothered with setting up certbot with nginx, then consider using Caddy for automatic HTTPS if there's not much else there I guess.

For FlatHub store publication those things would be required, once the app is ready for prime time debut there:

- fixing the https domain
- uploading screenshots with captions to metainfo (they should be taken with Spectacle and default KDE appearance settings; sadly my VM for that is currently not operational...)
- putting up release/changelog entry in metainfo (it doesn't need the URL, but it needs at minimum version name and date!)
- creating the PR under flathub org (I can do that, since I already have some experience dealing with all of that)
- for the app to not show yellow "Unverified", it'd also need to place a text file under `https://glabels.org/.well-known/org.flathub.VerifiedApps.txt` (with contents known after the app is published and one of the added maintainers logs into flathub site and grabs the token to put there)

Right now the only other potential blocker is that someone already put the legacy gLabels out there as unofficial package: https://flathub.org/en/apps/org.gnome.glabels-3 So I imagine maybe the old one should be renamed to `gLabels 3`, and maybe the new one `gLabels 4`, or just `gLabels` for simplicity...? Not sure what's the best solution. The old ID can't be re-used. In worst case the old app could be taken down and its ID supplied in our new metainfo as something that the new app replaces, but this isn't ideal since the import of old format isn't good enough to pick up the work right away... (so presumably it'd be ideal to keep both apps up I guess)

Nonetheless the issues above are for when publication to FlatHub is imminent, not blockers for merging this changeset and local builds.