### PR TITLE
Fix type mismatch

### DIFF
--- a/model/ParserState.cpp
+++ b/model/ParserState.cpp
@@ -78,7 +78,7 @@ namespace glabels
 
 
 		void
-		ParserState::advanceChars( unsigned int i )
+		ParserState::advanceChars( qsizetype i )
 		{
 			mPos = std::min( mPos + i, mString->size() );
 		}

--- a/model/ParserState.h
+++ b/model/ParserState.h
@@ -43,7 +43,7 @@ namespace glabels
 			qsizetype pos() const;
 			qsizetype charsLeft() const;
 
-			void advanceChars( unsigned int i );
+			void advanceChars( qsizetype i );
 
 
 		private:


### PR DESCRIPTION
This fails on 32 bit arches:

model/ParserState.cpp:83:40: error: no matching function for call to ‘min(unsigned int, qsizetype)’

Change parameter to qsizetype as well so types match.