### PR TITLE
Allow user roll templates to have customisable length

### DIFF
--- a/model/XmlTemplateCreator.cpp
+++ b/model/XmlTemplateCreator.cpp
@@ -61,7 +61,7 @@ namespace glabels
 				           << ": " << file.errorString();
 				return false;
 			}
-			
+
 			return true;
 		}
 
@@ -254,7 +254,7 @@ namespace glabels
 			XmlUtil::setLengthAttr( node, "width",          frame->w() );
 			XmlUtil::setLengthAttr( node, "height",         frame->h() );
 			XmlUtil::setLengthAttr( node, "min_height",     frame->hMin() );
-			XmlUtil::setLengthAttr( node, "max_height",     frame->hMin() );
+			XmlUtil::setLengthAttr( node, "max_height",     frame->hMax() );
 			XmlUtil::setLengthAttr( node, "default_height", frame->hDefault() );
 
 			createLabelNodeCommon( node, frame );


### PR DESCRIPTION
When testing #233 I created a file called `~/.config/glabels.org/glabels-qtBrother_12mm P-Touch.template`
```xml
<!DOCTYPE Glabels-templates>
<Glabels-templates>
  <Template brand="Brother" part="12mm P-Touch" _description="Continuous label 12 mm suitable for P-Touch label printers"
            size="roll" roll_width="17mm" width="11.98mm" >
    <Meta category="label"/>
    <Meta category="mail"/> 
    <Label-continuous id="0" width="11.98mm" min_height="5mm" max_height="1000mm" default_height="50mm" >
      <Markup-margin x_size="1.5mm" y_size="2.0mm" />
      <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
    </Label-continuous>
  </Template>
</Glabels-templates>
```
When gLables is next opened it replaces it with:
```xml
<!DOCTYPE Glabels-templates>
<Glabels-templates>
 <Template brand="Brother" description="Continuous label 12 mm suitable for P-Touch label printers" height="141.732pt" part="12mm P-Touch" roll_width="48.189pt" size="roll" width="33.9591pt">
  <Label-continuous default_height="141.732pt" height="141.732pt" id="0" max_height="14.1732pt" min_height="14.1732pt" width="33.9591pt">
   <Markup-margin x_size="4.25197pt" y_size="5.66929pt"/>
   <Layout dx="0pt" dy="0pt" nx="1" ny="1" x0="0pt" y0="0pt"/>
  </Label-continuous>
 </Template>
</Glabels-templates>
```
note `max_height`=`min_height`
While this didn't cause issues on that run, after re-opening gLabels again, `Properties`>`Adjustable Parameters`>`Label Length:` was fixed to `5.00 mm`


Not sure if there's a need to overwrite user templates on app startup? But this seems like a good thing to fix regardless.