### PR TITLE
Polling of available printers in now asynchronous

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ if (MINGW)
    set (CMAKE_PREFIX_PATH ${MINGW_BASE_DIR} )
 endif ()
 
-find_package (Qt6 6.2 REQUIRED COMPONENTS Core Gui Widgets PrintSupport Xml Svg LinguistTools Test)
+find_package (Qt6 6.2 REQUIRED COMPONENTS Concurrent Core Gui Widgets PrintSupport Xml Svg LinguistTools Test)
 
 if (WIN32)
    # Locate Qt directories

--- a/glabels/CMakeLists.txt
+++ b/glabels/CMakeLists.txt
@@ -138,6 +138,7 @@ target_include_directories (glabels-qt
 
 target_link_libraries (glabels-qt
   Model
+  Qt6::Concurrent
   Qt6::Widgets
 )
 

--- a/glabels/PrintView.cpp
+++ b/glabels/PrintView.cpp
@@ -48,8 +48,8 @@ namespace glabels
 		
 		auto* printerMonitor = PrinterMonitor::instance();
 		loadDestinations( printerMonitor->availablePrinters() );
-		connect( printerMonitor, SIGNAL(availablePrintersChanged(const QStringList&)),
-		         this, SLOT(onAvailablePrintersChanged(const QStringList&)) );
+		connect( printerMonitor, SIGNAL(availablePrintersChanged(QStringList)),
+		         this, SLOT(onAvailablePrintersChanged(QStringList)) );
 		
 		setDestination( model::Settings::recentPrinter() );
 
@@ -74,7 +74,7 @@ namespace glabels
 	///
 	/// Available printers changed handler
 	///
-	void PrintView::onAvailablePrintersChanged( const QStringList& printers )
+	void PrintView::onAvailablePrintersChanged( QStringList printers )
 	{
 		auto savedSelection = destinationCombo->currentText();
 		loadDestinations( printers );

--- a/glabels/PrintView.h
+++ b/glabels/PrintView.h
@@ -57,7 +57,7 @@ namespace glabels
 		// Slots
 		/////////////////////////////////
 	private slots:
-		void onAvailablePrintersChanged( const QStringList& printers );
+		void onAvailablePrintersChanged( QStringList printers );
 		void onModelChanged();
 		void updateView();
 		void onFormChanged();

--- a/glabels/PrinterMonitor.h
+++ b/glabels/PrinterMonitor.h
@@ -22,6 +22,8 @@
 #define PrinterMonitor_h
 
 
+#include <QFuture>
+#include <QMutex>
 #include <QObject>
 #include <QStringList>
 #include <QTimer>
@@ -53,7 +55,7 @@ namespace glabels
 		// Public methods
 		/////////////////////////////////
 	public:
-		const QStringList& availablePrinters() const;
+		QStringList availablePrinters();
 
 
 		/////////////////////////////////
@@ -67,7 +69,14 @@ namespace glabels
 		// Signals
 		/////////////////////////////////
 	signals:
-		void availablePrintersChanged( const QStringList& availablePrinters );
+		void availablePrintersChanged( QStringList availablePrinters );
+
+
+		/////////////////////////////////
+		// Private methods
+		/////////////////////////////////
+	private:
+		void asyncPoll();
 
 
 		/////////////////////////////////
@@ -77,8 +86,11 @@ namespace glabels
 		static std::unique_ptr<PrinterMonitor> mInstance;
 
 		std::unique_ptr<QTimer> mTimer;
+		
 		QStringList mCurrentAvailablePrinters;
+		QMutex      mCurrentAvailablePrintersMutex;
 
+		QFuture<void> mPollStatus;
 	};
 
 }


### PR DESCRIPTION
- Increased polling interval from 1s to 10s
- Use QtConcurrent::run to initiate a poll asynchronously to main event loop
- Do not initiate a poll if the previous poll has not completed
- Use copies instead of references to mCurrentAvailablePrinters in public API