### PR TITLE
Implement sizeHint in TemplatePicker's HTML item delegate.

### DIFF
--- a/glabels/TemplatePicker.cpp
+++ b/glabels/TemplatePicker.cpp
@@ -43,14 +43,12 @@ namespace
         //
         // Based on solutions at
         // https://stackoverflow.com/questions/1956542/how-to-make-item-view-render-rich-html-text-in-qt/1956781#1956781
-        // Note:  assumes that the text rectangle does not need to be resized, so does not reimplement sizeHint().
-        //        This delegate does not work correctly in IconMode, and may not work correctly in other applications,
-        //        for instance, when the height is not dominated by the icon.
         //
         class HtmlDelegate : public QStyledItemDelegate
         {
         protected:
-                void paint ( QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index ) const override;
+                void paint ( QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index ) const override;
+                QSize sizeHint ( const QStyleOptionViewItem& option, const QModelIndex& index ) const override;
         };
 
 
@@ -88,6 +86,18 @@ namespace
                 painter->setClipRect( textRect.translated( -textRect.topLeft() ) );
                 doc.documentLayout()->draw( painter, ctx );
                 painter->restore();
+        }
+
+
+        QSize HtmlDelegate::sizeHint( const QStyleOptionViewItem& option, const QModelIndex& index ) const
+        {
+                auto opt = option;
+                initStyleOption( &opt, index );
+
+                QTextDocument doc;
+                doc.setHtml( opt.text );
+                doc.setTextWidth( opt.rect.width() );
+                return QSize( doc.idealWidth(), doc.size().height() );
         }
 
 }


### PR DESCRIPTION
Height is not always dominated by icon size on all platforms, potentially cutting off text.