### PR TITLE
Update README.md regarding the Archlinux package

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Some third-party packages may be available available:
 
 | Platform  | Files                                                                                | Notes                                                         |
 |:----------|:-------------------------------------------------------------------------------------|:--------------------------------------------------------------|
-| Archlinux | [Archlinux User Repository Page](https://aur.archlinux.org/packages/glabels-qt-git/) | Maintained by [Mario Blättermann](https://github.com/mariobl) |
+| Archlinux | [Archlinux User Repository Page](https://aur.archlinux.org/packages/glabels-qt-git/) | Maintained by [Maud Spierings](https://github.com/SpieringsAE) |
 | Ubuntu    | [PPA Page](https://code.launchpad.net/~krisives/+archive/ubuntu/glabels-qt)          | Maintained by [Kristopher Ives](https://github.com/krisives)  |
 
 


### PR DESCRIPTION
I'm no longer maintaining the Archlinux package. Changed to the name and Github page of the new maintainer.