### PR TITLE
Add Bluetooth thermal label printer support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,23 @@ endif ()
 
 find_package (Qt6 6.2 REQUIRED COMPONENTS Concurrent Core Gui Widgets PrintSupport Xml Svg LinguistTools Test)
 
+# Optional Bluetooth support for ESC/POS printers (Phomemo, etc.)
+option (ENABLE_BLUETOOTH_PRINTERS "Enable Bluetooth printer support (requires Qt6Bluetooth and Qt6SerialPort)" ON)
+if (ENABLE_BLUETOOTH_PRINTERS)
+	find_package (Qt6 6.2 COMPONENTS Bluetooth SerialPort)
+	if (Qt6Bluetooth_FOUND AND Qt6SerialPort_FOUND)
+		message (STATUS "Bluetooth printer support: ENABLED")
+		set (HAVE_BLUETOOTH_SUPPORT TRUE)
+		add_compile_definitions (HAVE_BLUETOOTH_SUPPORT)
+	else ()
+		message (WARNING "Bluetooth printer support: DISABLED (Qt6Bluetooth or Qt6SerialPort not found)")
+		set (HAVE_BLUETOOTH_SUPPORT FALSE)
+	endif ()
+else ()
+	message (STATUS "Bluetooth printer support: DISABLED (by option)")
+	set (HAVE_BLUETOOTH_SUPPORT FALSE)
+endif ()
+
 if (WIN32)
    # Locate Qt directories
    execute_process (COMMAND qtpaths --install-prefix OUTPUT_VARIABLE QT_BASE_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/backends/CMakeLists.txt
+++ b/backends/CMakeLists.txt
@@ -4,5 +4,6 @@
 #=======================================
 add_subdirectory (barcode)
 add_subdirectory (merge)
+add_subdirectory (printer)
 
 

--- a/backends/printer/Backend.cpp
+++ b/backends/printer/Backend.cpp
@@ -1,0 +1,28 @@
+//  Printer/Backend.cpp
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//
+//  This file is part of gLabels-qt.
+//
+//  gLabels-qt is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  gLabels-qt is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with gLabels-qt.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+
+#include "Backend.hpp"
+
+
+namespace glabels::printer
+{
+        // Backend is an abstract base class - no implementation needed
+}

--- a/backends/printer/Backend.hpp
+++ b/backends/printer/Backend.hpp
@@ -1,0 +1,69 @@
+//  Printer/Backend.hpp
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//
+//  This file is part of gLabels-qt.
+//
+//  gLabels-qt is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  gLabels-qt is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with gLabels-qt.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef printer_Backend_hpp
+#define printer_Backend_hpp
+
+
+#include <QString>
+
+
+namespace glabels::model
+{
+        // Forward reference
+        class PageRenderer;
+}
+
+
+namespace glabels::printer
+{
+
+        ///
+        /// Printer Backend Abstract Base Class
+        ///
+        class Backend
+        {
+                /////////////////////////////////
+                // Life Cycle
+                /////////////////////////////////
+        public:
+                virtual ~Backend() = default;
+
+
+                /////////////////////////////////
+                // Virtual Methods
+                /////////////////////////////////
+        public:
+                // Identification
+                virtual QString id() const = 0;
+                virtual QString name() const = 0;
+
+                // Print operation
+                virtual bool print( model::PageRenderer* renderer ) = 0;
+
+                // Availability
+                virtual bool isAvailable() const = 0;
+                virtual QString lastError() const = 0;
+        };
+
+}
+
+
+#endif // printer_Backend_hpp

--- a/backends/printer/CMakeLists.txt
+++ b/backends/printer/CMakeLists.txt
@@ -1,0 +1,43 @@
+
+project (Printer LANGUAGES CXX)
+
+
+set (Printer_sources
+	Backend.cpp
+	Factory.cpp
+	QtPrinterBackend.cpp
+	PhomemoBackend.cpp
+	transport/BluetoothSerial.cpp
+	protocol/PhomemoProtocol.cpp
+)
+
+set (Printer_qobject_headers
+	Factory.hpp
+)
+
+qt6_wrap_cpp (Printer_moc_sources ${Printer_qobject_headers})
+
+add_library (Printer STATIC
+	${Printer_sources}
+	${Printer_moc_sources}
+)
+
+target_compile_features (Printer PUBLIC cxx_std_20)
+
+target_include_directories (Printer
+	PUBLIC .. ${CMAKE_CURRENT_BINARY_DIR}/.. ${CMAKE_SOURCE_DIR}
+)
+
+target_link_libraries (Printer
+	Qt6::Core
+	Qt6::Gui
+	Qt6::PrintSupport
+	Model
+)
+
+if (HAVE_BLUETOOTH_SUPPORT)
+	target_link_libraries (Printer
+		Qt6::Bluetooth
+		Qt6::SerialPort
+	)
+endif ()

--- a/backends/printer/Factory.cpp
+++ b/backends/printer/Factory.cpp
@@ -1,0 +1,113 @@
+//  Printer/Factory.cpp
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//
+//  This file is part of gLabels-qt.
+//
+//  gLabels-qt is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  gLabels-qt is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with gLabels-qt.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+
+#include "Factory.hpp"
+
+#include "Backend.hpp"
+#include "QtPrinterBackend.hpp"
+#include "PhomemoBackend.hpp"
+
+
+namespace glabels::printer
+{
+
+        //
+        // Static data
+        //
+        QMap<QString,Factory::BackendEntry> Factory::mBackendMap;
+
+
+        ///
+        /// Constructor
+        ///
+        Factory::Factory()
+        {
+                // Register Qt Printer backend (standard CUPS printers)
+                // Note: Currently not used - CUPS printers go through direct QPrinter path
+                registerBackend( "QtPrinter",
+                                 tr("Qt Printer System"),
+                                 QT_PRINTER,
+                                 &QtPrinterBackend::create );
+
+                // Register Phomemo Bluetooth backend (pattern: "BT:*")
+                registerBackend( "BT:",
+                                 tr("Phomemo Bluetooth Printer"),
+                                 BLUETOOTH_ESCPOS,
+                                 &PhomemoBackend::create );
+        }
+
+
+        ///
+        /// Initialize
+        ///
+        void Factory::init()
+        {
+                static Factory* singletonInstance = nullptr;
+                if ( !singletonInstance )
+                {
+                        singletonInstance = new Factory();
+                }
+        }
+
+
+        ///
+        /// Create Backend object
+        ///
+        Backend* Factory::createBackend( const QString& id )
+        {
+                // Try exact match first
+                if ( mBackendMap.contains( id ) )
+                {
+                        return mBackendMap[id].create( id );
+                }
+
+                // Try pattern matching (for Bluetooth devices: "BT:DeviceName:MAC")
+                for ( auto it = mBackendMap.begin(); it != mBackendMap.end(); ++it )
+                {
+                        if ( id.startsWith( it->idPattern ) )
+                        {
+                                return it->create( id );
+                        }
+                }
+
+                return nullptr;
+        }
+
+
+        ///
+        /// Register backend
+        ///
+        void Factory::registerBackend( const QString&   idPattern,
+                                       const QString&   name,
+                                       BackendType      type,
+                                       CreateFct        create )
+        {
+                BackendEntry backend;
+
+                backend.idPattern = idPattern;
+                backend.name      = name;
+                backend.type      = type;
+                backend.create    = create;
+
+                mBackendMap[ idPattern ] = backend;
+        }
+
+}

--- a/backends/printer/Factory.hpp
+++ b/backends/printer/Factory.hpp
@@ -1,0 +1,98 @@
+//  Printer/Factory.hpp
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//
+//  This file is part of gLabels-qt.
+//
+//  gLabels-qt is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  gLabels-qt is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with gLabels-qt.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef printer_Factory_hpp
+#define printer_Factory_hpp
+
+
+#include <QCoreApplication>
+#include <QString>
+#include <QMap>
+
+
+namespace glabels::printer
+{
+
+        // Forward references
+        class Backend;
+
+
+        ///
+        /// Printer Backend Factory
+        ///
+        class Factory
+        {
+                Q_DECLARE_TR_FUNCTIONS(Factory)
+
+
+                /////////////////////////////////
+                // Backend Type
+                /////////////////////////////////
+        public:
+                enum BackendType { QT_PRINTER, BLUETOOTH_ESCPOS };
+
+
+                /////////////////////////////////
+                // Life Cycle
+                /////////////////////////////////
+        protected:
+                Factory();
+
+
+                /////////////////////////////////
+                // Static methods
+                /////////////////////////////////
+        public:
+                static void init();
+
+                static Backend* createBackend( const QString& id );
+
+
+                /////////////////////////////////
+                // private methods
+                /////////////////////////////////
+        private:
+                using CreateFct = Backend* (*)( const QString& id );
+
+                static void registerBackend( const QString&   idPattern,
+                                             const QString&   name,
+                                             BackendType      type,
+                                             CreateFct        create );
+
+
+                /////////////////////////////////
+                // private data
+                /////////////////////////////////
+                class BackendEntry
+                {
+                public:
+                        QString     idPattern;
+                        QString     name;
+                        BackendType type;
+                        CreateFct   create;
+                };
+
+                static QMap<QString,BackendEntry> mBackendMap;
+        };
+
+}
+
+
+#endif // printer_Factory_hpp

--- a/backends/printer/PhomemoBackend.cpp
+++ b/backends/printer/PhomemoBackend.cpp
@@ -1,0 +1,420 @@
+//  Printer/PhomemoBackend.cpp
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//
+//  This file is part of gLabels-qt.
+//
+//  gLabels-qt is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  gLabels-qt is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with gLabels-qt.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+
+#include "PhomemoBackend.hpp"
+
+#include "protocol/PhomemoProtocol.hpp"
+#include "transport/BluetoothSerial.hpp"
+#include "model/Model.hpp"
+#include "model/PageRenderer.hpp"
+
+#include <QPainter>
+#include <QTransform>
+
+
+namespace glabels::printer
+{
+
+        ///
+        /// Constructor
+        ///
+        PhomemoBackend::PhomemoBackend( const QString& deviceName,
+                                        const QBluetoothAddress& address )
+                : mDeviceName( deviceName )
+                , mAddress( address )
+        {
+        }
+
+
+        ///
+        /// Get backend ID (format: "BT:DeviceName:MAC")
+        ///
+        QString PhomemoBackend::id() const
+        {
+                return QString("BT:%1:%2").arg(mDeviceName).arg(mAddress.toString());
+        }
+
+
+        ///
+        /// Get backend name (display name)
+        ///
+        QString PhomemoBackend::name() const
+        {
+                return mDeviceName;
+        }
+
+
+        ///
+        /// Print to Phomemo device
+        ///
+        bool PhomemoBackend::print( model::PageRenderer* renderer )
+        {
+                // 1. Connect to device
+                if ( !connect() )
+                {
+                        return false;
+                }
+
+                // 2. Send initialization sequence
+                QByteArray initSeq = protocol::PhomemoProtocol::initSequence();
+                if ( !mTransport->write( initSeq ) )
+                {
+                        mLastError = QString("Failed to send initialization: %1")
+                                     .arg( mTransport->lastError() );
+                        disconnect();
+                        return false;
+                }
+                mTransport->flush();
+
+                // 3. Render PageRenderer to QImage
+                QImage rawImage = renderToImage( renderer );
+                if ( rawImage.isNull() )
+                {
+                        mLastError = "Failed to render label to image";
+                        disconnect();
+                        return false;
+                }
+
+                // 4. Get label width from model to calculate margins
+                double labelWidthMm = 12.0;  // Default to 12mm
+                const model::Model* model = renderer->model();
+                if ( model )
+                {
+                        const model::Frame* frame = model->tmplate().frame();
+                        if ( frame )
+                        {
+                                labelWidthMm = frame->w().mm();
+                        }
+                }
+
+                // 5. Add print margins if label is wider than printable area
+                QImage marginedImage = addPrintMargins( rawImage, labelWidthMm );
+                if ( marginedImage.isNull() )
+                {
+                        mLastError = "Failed to add print margins";
+                        disconnect();
+                        return false;
+                }
+
+                // 6. Preprocess image for Phomemo (resize, invert, monochrome)
+                QImage processedImage = preprocessImage( marginedImage );
+                if ( processedImage.isNull() )
+                {
+                        mLastError = "Failed to preprocess image";
+                        disconnect();
+                        return false;
+                }
+
+                // 5. Encode image to ESC/POS protocol (handles chunking)
+                QList<QByteArray> packets = protocol::PhomemoProtocol::encodeImage( processedImage );
+
+                // 6. Send each chunk
+                for ( const auto& packet : packets )
+                {
+                        if ( !mTransport->write( packet ) )
+                        {
+                                mLastError = QString("Failed to send image data: %1")
+                                             .arg( mTransport->lastError() );
+                                disconnect();
+                                return false;
+                        }
+                        mTransport->flush();
+                }
+
+                // 7. Disconnect
+                disconnect();
+
+                mLastError.clear();
+                return true;
+        }
+
+
+        ///
+        /// Check if device is available (Bluetooth device is paired)
+        ///
+        bool PhomemoBackend::isAvailable() const
+        {
+                // For now, assume device is available if we have a valid address
+                // Could be improved by checking Bluetooth device list
+                return !mAddress.isNull();
+        }
+
+
+        ///
+        /// Get last error message
+        ///
+        QString PhomemoBackend::lastError() const
+        {
+                return mLastError;
+        }
+
+
+        ///
+        /// Connect to Bluetooth device
+        ///
+        bool PhomemoBackend::connect()
+        {
+                if ( !mTransport )
+                {
+                        mTransport.reset( new transport::BluetoothSerial( mAddress ) );
+                }
+
+                if ( !mTransport->open() )
+                {
+                        mLastError = QString("Failed to connect to %1: %2")
+                                     .arg(mDeviceName)
+                                     .arg(mTransport->lastError());
+                        return false;
+                }
+
+                return true;
+        }
+
+
+        ///
+        /// Disconnect from Bluetooth device
+        ///
+        void PhomemoBackend::disconnect()
+        {
+                if ( mTransport )
+                {
+                        mTransport->close();
+                }
+        }
+
+
+        ///
+        /// Render PageRenderer output to QImage
+        ///
+        QImage PhomemoBackend::renderToImage( model::PageRenderer* renderer )
+        {
+                // Check if renderer has a model
+                const model::Model* model = renderer->model();
+                if ( !model )
+                {
+                        qWarning() << "Phomemo: PageRenderer has no model!";
+                        return QImage();
+                }
+
+                qDebug() << "Phomemo: Renderer has model, checking template...";
+
+                // Get page dimensions from renderer
+                QRectF pageRect = renderer->pageRect();
+
+                qDebug() << "Phomemo: Page dimensions:" << pageRect.width() << "x" << pageRect.height() << "points";
+
+                // For continuous-feed printers like Phomemo, if page size is 0,
+                // use the label size instead (each label is a "page")
+                if ( pageRect.width() <= 0 || pageRect.height() <= 0 )
+                {
+                        qDebug() << "Phomemo: Page size is 0, using label dimensions instead";
+                        qDebug() << "Phomemo: Template - brand:" << model->tmplate().brand()
+                                 << "part:" << model->tmplate().part()
+                                 << "description:" << model->tmplate().description();
+
+                        // Get label dimensions from the template's frame
+                        const model::Frame* frame = model->tmplate().frame();
+                        if ( !frame )
+                        {
+                                qWarning() << "Phomemo: Template has no frame/label defined";
+                                return QImage();
+                        }
+
+                        pageRect = QRectF( 0, 0, frame->w().pt(), frame->h().pt() );
+
+                        qDebug() << "Phomemo: Using label dimensions:" << pageRect.width() << "x" << pageRect.height() << "points";
+                }
+
+                // Validate dimensions
+                if ( pageRect.width() <= 0 || pageRect.height() <= 0 )
+                {
+                        qWarning() << "Phomemo: Still have invalid dimensions after checking label size";
+                        return QImage();
+                }
+
+                // Create image with sufficient resolution (300 DPI)
+                // Convert points to pixels at 300 DPI (1 point = 300/72 pixels)
+                double scale = 300.0 / 72.0;
+                int imageWidth = qRound( pageRect.width() * scale );
+                int imageHeight = qRound( pageRect.height() * scale );
+
+                qDebug() << "Phomemo: Image size:" << imageWidth << "x" << imageHeight << "pixels";
+
+                // Validate calculated dimensions
+                if ( imageWidth <= 0 || imageHeight <= 0 )
+                {
+                        qWarning() << "Phomemo: Calculated image dimensions are invalid:" << imageWidth << "x" << imageHeight;
+                        return QImage();
+                }
+
+                // Create canvas with ARGB32_Premultiplied format (supports QPainter)
+                QImage image( imageWidth, imageHeight, QImage::Format_ARGB32_Premultiplied );
+
+                if ( image.isNull() )
+                {
+                        qWarning() << "Phomemo: Failed to create QImage";
+                        return QImage();
+                }
+
+                image.fill( Qt::white );
+
+                qDebug() << "Phomemo: Image created successfully, initializing painter";
+
+                // Render to image
+                QPainter painter( &image );
+                if ( !painter.isActive() )
+                {
+                        qWarning() << "Phomemo: Failed to create QPainter for image rendering";
+                        qWarning() << "Phomemo: Image format:" << image.format();
+                        qWarning() << "Phomemo: Image size:" << image.size();
+                        qWarning() << "Phomemo: Image depth:" << image.depth();
+                        return QImage();
+                }
+
+                qDebug() << "Phomemo: Painter active, scaling and rendering";
+                painter.scale( scale, scale );
+
+                // Render the current page
+                renderer->printPage( &painter );
+
+                painter.end();
+
+                qDebug() << "Phomemo: Rendering complete, converting format";
+
+                // Convert to RGB32 (remove alpha channel)
+                return image.convertToFormat( QImage::Format_RGB32 );
+        }
+
+
+        ///
+        /// Crop to printable area for labels wider than 12mm
+        /// Phomemo D30/D35 have 96-pixel (12mm) printable width regardless of label size
+        /// For 14mm/15mm labels, we crop to the center 12mm portion
+        /// The remaining width becomes physical margins on the label
+        ///
+        QImage PhomemoBackend::addPrintMargins( const QImage& source, double labelWidthMm )
+        {
+                const double printableWidthMm = protocol::PhomemoProtocol::PRINTABLE_WIDTH_MM;
+
+                // If label width <= printable width, no cropping needed
+                if ( labelWidthMm <= printableWidthMm )
+                {
+                        qDebug() << "Phomemo: Label width" << labelWidthMm << "mm <= printable width"
+                                 << printableWidthMm << "mm, no cropping needed";
+                        return source;
+                }
+
+                qDebug() << "Phomemo: Label width" << labelWidthMm << "mm > printable width"
+                         << printableWidthMm << "mm, cropping to center" << printableWidthMm << "mm";
+
+                // Calculate printable width in pixels
+                // Scale factor to convert mm to pixels (based on source image)
+                double mmToPixels = source.width() / labelWidthMm;
+                int printableWidthPx = qRound( printableWidthMm * mmToPixels );
+
+                // Calculate left edge of printable area (centered)
+                int leftEdgePx = (source.width() - printableWidthPx) / 2;
+
+                qDebug() << "Phomemo: Cropping - source width:" << source.width() << "px"
+                         << "printable width:" << printableWidthPx << "px"
+                         << "left edge:" << leftEdgePx << "px";
+
+                // Crop to center printable area
+                QImage cropped = source.copy( leftEdgePx, 0, printableWidthPx, source.height() );
+
+                qDebug() << "Phomemo: Cropped image size:" << cropped.width() << "x" << cropped.height();
+
+                return cropped;
+        }
+
+
+        ///
+        /// Preprocess image for Phomemo printer
+        /// 1. Resize to 96px width, maintain aspect ratio
+        /// 2. Invert colors (thermal printer)
+        /// 3. Convert to 1-bit monochrome
+        ///
+        /// Note: No rotation needed - our rendered image is already in portrait orientation (96px wide)
+        ///
+        QImage PhomemoBackend::preprocessImage( const QImage& source )
+        {
+                // Step 1: Resize to 96px width, maintaining aspect ratio
+                // Calculate height to preserve aspect ratio
+                int targetHeight = source.height() * protocol::PhomemoProtocol::IMAGE_WIDTH / source.width();
+
+                // Use IgnoreAspectRatio since we've already calculated the correct height
+                // This ensures we get exactly 96 pixels width (not 95)
+                QImage resized = source.scaled( protocol::PhomemoProtocol::IMAGE_WIDTH,
+                                                targetHeight,
+                                                Qt::IgnoreAspectRatio,
+                                                Qt::SmoothTransformation );
+
+                qDebug() << "Phomemo: After resize:" << resized.width() << "x" << resized.height();
+
+                // Step 2: Invert colors (thermal printer burns black areas, creating black on paper)
+                // After inversion: text becomes white, background becomes black
+                // Bit packing will set bit=1 for white pixels, causing thermal head to burn those areas black
+                resized.invertPixels();
+
+                // Step 3: Convert to 1-bit monochrome with dithering
+                QImage mono = resized.convertToFormat( QImage::Format_Mono,
+                                                       Qt::MonoOnly | Qt::ThresholdDither );
+
+                qDebug() << "Phomemo: Final preprocessed image:" << mono.width() << "x" << mono.height();
+
+                return mono;
+        }
+
+
+        ///
+        /// Factory create method
+        /// Parse ID format: "BT:DeviceName:MAC"
+        ///
+        Backend* PhomemoBackend::create( const QString& id )
+        {
+                QStringList parts = id.split( ':' );
+
+                if ( parts.size() < 3 || parts[0] != "BT" )
+                {
+                        return nullptr;
+                }
+
+                QString deviceName = parts[1];
+                QString macAddress = parts[2];
+
+                // Handle MAC addresses that may contain colons
+                // Format could be: "BT:Phomemo D30:AA:BB:CC:DD:EE:FF"
+                if ( parts.size() > 3 )
+                {
+                        // Reconstruct MAC address from remaining parts
+                        macAddress = parts.mid(2).join(':');
+                }
+
+                QBluetoothAddress address( macAddress );
+                if ( address.isNull() )
+                {
+                        return nullptr;
+                }
+
+                return new PhomemoBackend( deviceName, address );
+        }
+
+}

--- a/backends/printer/PhomemoBackend.hpp
+++ b/backends/printer/PhomemoBackend.hpp
@@ -1,0 +1,100 @@
+//  Printer/PhomemoBackend.hpp
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//
+//  This file is part of gLabels-qt.
+//
+//  gLabels-qt is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  gLabels-qt is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with gLabels-qt.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef printer_PhomemoBackend_hpp
+#define printer_PhomemoBackend_hpp
+
+
+#include "Backend.hpp"
+
+#include <QBluetoothAddress>
+#include <QImage>
+#include <QString>
+#include <memory>
+
+
+namespace glabels::printer::transport
+{
+        class BluetoothSerial;
+}
+
+
+namespace glabels::printer
+{
+
+        ///
+        /// Phomemo Bluetooth Printer Backend (D30, D35, M02S, etc.)
+        ///
+        class PhomemoBackend : public Backend
+        {
+                /////////////////////////////////
+                // Life Cycle
+                /////////////////////////////////
+        public:
+                PhomemoBackend( const QString& deviceName,
+                                const QBluetoothAddress& address );
+
+
+                /////////////////////////////////
+                // Backend Implementation
+                /////////////////////////////////
+        public:
+                QString id() const override;
+                QString name() const override;
+                bool print( model::PageRenderer* renderer ) override;
+                bool isAvailable() const override;
+                QString lastError() const override;
+
+
+                /////////////////////////////////
+                // Factory Methods
+                /////////////////////////////////
+        public:
+                static Backend* create( const QString& id );
+
+
+                /////////////////////////////////
+                // Private Methods
+                /////////////////////////////////
+        private:
+                // Connection management
+                bool connect();
+                void disconnect();
+
+                // Image rendering and preprocessing
+                QImage renderToImage( model::PageRenderer* renderer );
+                QImage addPrintMargins( const QImage& source, double labelWidthMm );
+                QImage preprocessImage( const QImage& source );
+
+
+                /////////////////////////////////
+                // Private Data
+                /////////////////////////////////
+        private:
+                QString                                       mDeviceName;
+                QBluetoothAddress                             mAddress;
+                std::unique_ptr<transport::BluetoothSerial>   mTransport;
+                QString                                       mLastError;
+        };
+
+}
+
+
+#endif // printer_PhomemoBackend_hpp

--- a/backends/printer/QtPrinterBackend.cpp
+++ b/backends/printer/QtPrinterBackend.cpp
@@ -1,0 +1,110 @@
+//  Printer/QtPrinterBackend.cpp
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//
+//  This file is part of gLabels-qt.
+//
+//  gLabels-qt is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  gLabels-qt is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with gLabels-qt.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+
+#include "QtPrinterBackend.hpp"
+
+#include "model/PageRenderer.hpp"
+
+#include <QPrinter>
+#include <QPrinterInfo>
+
+
+namespace glabels::printer
+{
+
+        ///
+        /// Constructor
+        ///
+        QtPrinterBackend::QtPrinterBackend( const QString& printerName )
+                : mPrinterName( printerName )
+        {
+        }
+
+
+        ///
+        /// Get backend ID
+        ///
+        QString QtPrinterBackend::id() const
+        {
+                return mPrinterName;
+        }
+
+
+        ///
+        /// Get backend name
+        ///
+        QString QtPrinterBackend::name() const
+        {
+                return mPrinterName;
+        }
+
+
+        ///
+        /// Print using Qt Printer (CUPS)
+        ///
+        bool QtPrinterBackend::print( model::PageRenderer* renderer )
+        {
+                QPrinter printer( QPrinter::HighResolution );
+                printer.setPrinterName( mPrinterName );
+                printer.setColorMode( QPrinter::Color );
+
+                try
+                {
+                        renderer->print( &printer );
+                        mLastError.clear();
+                        return true;
+                }
+                catch ( ... )
+                {
+                        mLastError = QString("Failed to print to %1").arg(mPrinterName);
+                        return false;
+                }
+        }
+
+
+        ///
+        /// Check if printer is available
+        ///
+        bool QtPrinterBackend::isAvailable() const
+        {
+                auto printerInfo = QPrinterInfo::printerInfo( mPrinterName );
+                return !printerInfo.isNull();
+        }
+
+
+        ///
+        /// Get last error message
+        ///
+        QString QtPrinterBackend::lastError() const
+        {
+                return mLastError;
+        }
+
+
+        ///
+        /// Factory create method
+        ///
+        Backend* QtPrinterBackend::create( const QString& id )
+        {
+                return new QtPrinterBackend( id );
+        }
+
+}

--- a/backends/printer/QtPrinterBackend.hpp
+++ b/backends/printer/QtPrinterBackend.hpp
@@ -1,0 +1,74 @@
+//  Printer/QtPrinterBackend.hpp
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//
+//  This file is part of gLabels-qt.
+//
+//  gLabels-qt is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  gLabels-qt is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with gLabels-qt.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef printer_QtPrinterBackend_hpp
+#define printer_QtPrinterBackend_hpp
+
+
+#include "Backend.hpp"
+
+#include <QString>
+
+
+namespace glabels::printer
+{
+
+        ///
+        /// Qt Printer Backend (wraps QPrinter for CUPS printers)
+        ///
+        class QtPrinterBackend : public Backend
+        {
+                /////////////////////////////////
+                // Life Cycle
+                /////////////////////////////////
+        public:
+                QtPrinterBackend( const QString& printerName );
+
+
+                /////////////////////////////////
+                // Backend Implementation
+                /////////////////////////////////
+        public:
+                QString id() const override;
+                QString name() const override;
+                bool print( model::PageRenderer* renderer ) override;
+                bool isAvailable() const override;
+                QString lastError() const override;
+
+
+                /////////////////////////////////
+                // Factory Methods
+                /////////////////////////////////
+        public:
+                static Backend* create( const QString& id );
+
+
+                /////////////////////////////////
+                // Private Data
+                /////////////////////////////////
+        private:
+                QString mPrinterName;
+                QString mLastError;
+        };
+
+}
+
+
+#endif // printer_QtPrinterBackend_hpp

--- a/backends/printer/protocol/PhomemoProtocol.cpp
+++ b/backends/printer/protocol/PhomemoProtocol.cpp
@@ -1,0 +1,165 @@
+//  Printer/Protocol/PhomemoProtocol.cpp
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//
+//  This file is part of gLabels-qt.
+//
+//  gLabels-qt is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  gLabels-qt is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with gLabels-qt.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+
+#include "PhomemoProtocol.hpp"
+
+
+namespace glabels::printer::protocol
+{
+
+        ///
+        /// Generate initialization sequence
+        /// 7-packet initialization for Phomemo printers
+        ///
+        QByteArray PhomemoProtocol::initSequence()
+        {
+                return QByteArray::fromHex("1f1138") +
+                       QByteArray::fromHex("1f11121f1113") +
+                       QByteArray::fromHex("1f1109") +
+                       QByteArray::fromHex("1f1111") +
+                       QByteArray::fromHex("1f1119") +
+                       QByteArray::fromHex("1f1107") +
+                       QByteArray::fromHex("1f110a1f110202");
+        }
+
+
+        ///
+        /// Generate image header with specific height
+        /// Format: 1f1124001b401d763000WWWWHHHH
+        /// Where WWWW is width in bytes (little-endian), HHHH is height in pixels (little-endian)
+        ///
+        QByteArray PhomemoProtocol::imageHeader( int height )
+        {
+                // Base header: 1f1124001b401d763000 (10 bytes)
+                // ESC/POS GS v 0 command for raster bit image
+                QByteArray header = QByteArray::fromHex("1f1124001b401d763000");
+
+                // Width: 0x000C (12 bytes = 96 pixels) - little endian
+                header.append( char(0x0C) );
+                header.append( char(0x00) );
+
+                // Height: little endian (variable based on chunk)
+                header.append( char(height & 0xFF) );
+                header.append( char((height >> 8) & 0xFF) );
+
+                return header;
+        }
+
+
+        ///
+        /// Pack image bits (MSB-first, 12 bytes per line)
+        ///
+        QByteArray PhomemoProtocol::packBits( const QImage& mono1bit )
+        {
+                QByteArray packed;
+                int height = mono1bit.height();
+                int width = mono1bit.width();
+
+                for ( int y = 0; y < height; y++ )
+                {
+                        // 96 pixels = 12 bytes per scanline
+                        for ( int byteX = 0; byteX < 12; byteX++ )
+                        {
+                                quint8 byte = 0;
+
+                                for ( int bit = 0; bit < 8; bit++ )
+                                {
+                                        int x = byteX * 8 + bit;
+
+                                        if ( x < width )
+                                        {
+                                                // Get pixel value (monochrome image)
+                                                QRgb pixel = mono1bit.pixel( x, y );
+                                                int gray = qGray( pixel );
+
+                                                // White pixel (>= 128) sets bit to 1
+                                                // After inversion, white pixels are the text we want to print
+                                                if ( gray >= 128 )
+                                                {
+                                                        byte |= (1 << (7 - bit));  // MSB first
+                                                }
+                                        }
+                                }
+
+                                packed.append( byte );
+                        }
+                }
+
+                return packed;
+        }
+
+
+        ///
+        /// Split image into chunks (max 255px height each)
+        ///
+        QList<QImage> PhomemoProtocol::splitIntoChunks( const QImage& image )
+        {
+                QList<QImage> chunks;
+                int height = image.height();
+                int numChunks = (height + MAX_CHUNK_HEIGHT - 1) / MAX_CHUNK_HEIGHT;
+
+                for ( int i = 0; i < numChunks; i++ )
+                {
+                        int yStart = i * MAX_CHUNK_HEIGHT;
+                        int chunkHeight = qMin( MAX_CHUNK_HEIGHT, height - yStart );
+
+                        QImage chunk = image.copy( 0, yStart, image.width(), chunkHeight );
+                        chunks.append( chunk );
+                }
+
+                return chunks;
+        }
+
+
+        ///
+        /// Encode image to ESC/POS picture mode
+        /// Returns single packet with header (total height) + all data
+        ///
+        /// IMPORTANT: Send ONE header with total height, then all image data.
+        /// Don't send separate headers per chunk!
+        ///
+        QList<QByteArray> PhomemoProtocol::encodeImage( const QImage& image )
+        {
+                QList<QByteArray> packets;
+
+                // Convert to monochrome if not already
+                QImage mono = image;
+                if ( mono.format() != QImage::Format_Mono )
+                {
+                        mono = mono.convertToFormat( QImage::Format_Mono,
+                                                     Qt::MonoOnly | Qt::ThresholdDither );
+                }
+
+                // Create single packet with header for TOTAL height + all image data
+                QByteArray packet;
+
+                // Add image header with TOTAL height (not chunked)
+                packet.append( imageHeader( mono.height() ) );
+
+                // Pack and append ALL image data at once
+                packet.append( packBits( mono ) );
+
+                packets.append( packet );
+
+                return packets;
+        }
+
+}

--- a/backends/printer/protocol/PhomemoProtocol.hpp
+++ b/backends/printer/protocol/PhomemoProtocol.hpp
@@ -1,0 +1,75 @@
+//  Printer/Protocol/PhomemoProtocol.hpp
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//
+//  This file is part of gLabels-qt.
+//
+//  gLabels-qt is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  gLabels-qt is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with gLabels-qt.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef printer_protocol_PhomemoProtocol_hpp
+#define printer_protocol_PhomemoProtocol_hpp
+
+
+#include <QByteArray>
+#include <QImage>
+#include <QList>
+
+
+namespace glabels::printer::protocol
+{
+
+        ///
+        /// Phomemo ESC/POS Protocol (Picture Mode)
+        ///
+        class PhomemoProtocol
+        {
+                /////////////////////////////////
+                // Constants
+                /////////////////////////////////
+        public:
+                static constexpr int IMAGE_WIDTH = 96;            // Fixed width in pixels (thermal head)
+                static constexpr double PRINTABLE_WIDTH_MM = 12.0; // Printable width in mm
+                static constexpr int MAX_CHUNK_HEIGHT = 255;      // Max height per chunk
+
+
+                /////////////////////////////////
+                // Static Methods
+                /////////////////////////////////
+        public:
+                // Generate initialization sequence (7 packets)
+                static QByteArray initSequence();
+
+                // Encode image to ESC/POS picture mode (handles chunking)
+                static QList<QByteArray> encodeImage( const QImage& image );
+
+
+                /////////////////////////////////
+                // Private Helper Methods
+                /////////////////////////////////
+        private:
+                // Generate image header with specific height
+                static QByteArray imageHeader( int height );
+
+                // Pack image bits (MSB-first, 12 bytes per line)
+                static QByteArray packBits( const QImage& mono1bit );
+
+                // Split image into chunks (max 255px height each)
+                static QList<QImage> splitIntoChunks( const QImage& image );
+        };
+
+}
+
+
+#endif // printer_protocol_PhomemoProtocol_hpp

--- a/backends/printer/transport/BluetoothSerial.cpp
+++ b/backends/printer/transport/BluetoothSerial.cpp
@@ -1,0 +1,511 @@
+//  Printer/Transport/BluetoothSerial.cpp
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//
+//  This file is part of gLabels-qt.
+//
+//  gLabels-qt is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  gLabels-qt is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with gLabels-qt.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+
+#include "BluetoothSerial.hpp"
+
+#include <QBluetoothServiceDiscoveryAgent>
+#include <QBluetoothServiceInfo>
+#include <QBluetoothSocket>
+#include <QBluetoothUuid>
+#include <QCoreApplication>
+#include <QDebug>
+#include <QDir>
+#include <QEventLoop>
+#include <QFile>
+#include <QTimer>
+
+
+namespace glabels::printer::transport
+{
+
+        ///
+        /// Constructor
+        ///
+        BluetoothSerial::BluetoothSerial( const QBluetoothAddress& address )
+                : mAddress( address )
+        {
+        }
+
+
+        ///
+        /// Destructor
+        ///
+        BluetoothSerial::~BluetoothSerial()
+        {
+                close();
+        }
+
+
+        ///
+        /// Open Bluetooth connection (tries multiple modes)
+        ///
+        /// Connection modes:
+        ///   1. (Linux only) /dev/rfcomm* device - uses system-bound RFCOMM device
+        ///   2. (Cross-platform) Service discovery - discovers SPP service first
+        ///   3. (Cross-platform) Direct UUID - connects directly to SPP UUID
+        ///
+        /// On Windows, mode 1 is skipped and modes 2/3 are used.
+        ///
+        bool BluetoothSerial::open()
+        {
+                if ( isOpen() )
+                {
+                        return true;
+                }
+
+                // Mode 1: Try to use existing /dev/rfcomm* device (Linux only)
+#ifdef Q_OS_LINUX
+                qDebug() << "Phomemo: Attempting to connect via existing /dev/rfcomm* device...";
+                if ( openViaRfcommDevice() )
+                {
+                        qDebug() << "Phomemo: Connected via /dev/rfcomm* device";
+                        return true;
+                }
+#else
+                qDebug() << "Phomemo: Skipping /dev/rfcomm* device mode (not supported on this platform)";
+#endif
+
+                // Mode 2: Try service discovery to find correct channel
+                qDebug() << "Phomemo: Attempting to connect via service discovery...";
+                if ( openViaServiceDiscovery() )
+                {
+                        qDebug() << "Phomemo: Connected via service discovery";
+                        return true;
+                }
+
+                // Mode 3: Fall back to direct UUID connection
+                qDebug() << "Phomemo: Attempting to connect via direct UUID...";
+                if ( openViaBluetoothSocket() )
+                {
+                        qDebug() << "Phomemo: Connected via direct UUID";
+                        return true;
+                }
+
+                // All modes failed
+                qDebug() << "Phomemo: All connection modes failed";
+                return false;
+        }
+
+
+        ///
+        /// Close Bluetooth connection
+        ///
+        void BluetoothSerial::close()
+        {
+                if ( mPort )
+                {
+                        if ( mPort->isOpen() )
+                        {
+                                mPort->close();
+                        }
+                        mPort.reset();
+                }
+
+                if ( mSocket )
+                {
+                        if ( mSocket->isOpen() )
+                        {
+                                mSocket->close();
+                        }
+                        mSocket.reset();
+                }
+        }
+
+
+        ///
+        /// Check if connection is open
+        ///
+        bool BluetoothSerial::isOpen() const
+        {
+                return ( mPort && mPort->isOpen() ) || ( mSocket && mSocket->isOpen() );
+        }
+
+
+        ///
+        /// Write data to Bluetooth device
+        ///
+        bool BluetoothSerial::write( const QByteArray& data )
+        {
+                qDebug() << "Phomemo: write() called with" << data.size() << "bytes";
+                qDebug() << "Phomemo: isOpen():" << isOpen()
+                         << "mPort:" << (mPort ? "exists" : "null")
+                         << "mSocket:" << (mSocket ? "exists" : "null");
+
+                if ( mSocket )
+                {
+                        qDebug() << "Phomemo: Socket state:" << mSocket->state()
+                                 << "isOpen:" << mSocket->isOpen()
+                                 << "error:" << mSocket->error();
+                }
+
+                if ( !isOpen() )
+                {
+                        mLastError = "Cannot write while not connected";
+                        return false;
+                }
+
+                // Write via QSerialPort if using /dev/rfcomm* mode
+                if ( mPort && mPort->isOpen() )
+                {
+                        qint64 bytesWritten = mPort->write( data );
+                        if ( bytesWritten != data.size() )
+                        {
+                                mLastError = QString("Failed to write data: %1")
+                                             .arg( mPort->errorString() );
+                                return false;
+                        }
+                        return true;
+                }
+
+                // Write via QBluetoothSocket if using socket mode
+                if ( mSocket && mSocket->isOpen() )
+                {
+                        qDebug() << "Phomemo: Attempting to write" << data.size() << "bytes via socket...";
+                        qint64 bytesWritten = mSocket->write( data );
+                        qDebug() << "Phomemo: mSocket->write() returned:" << bytesWritten << "bytes";
+
+                        if ( bytesWritten != data.size() )
+                        {
+                                mLastError = QString("Failed to write data: %1")
+                                             .arg( mSocket->errorString() );
+                                qDebug() << "Phomemo: Write size mismatch! Expected:" << data.size() << "Actual:" << bytesWritten;
+                                return false;
+                        }
+
+                        // Note: Don't use waitForBytesWritten() for Bluetooth sockets - it often times out
+                        // even when data is being transmitted correctly. Just write and return.
+                        qDebug() << "Phomemo: Write successful (queued" << bytesWritten << "bytes)";
+                        return true;
+                }
+
+                qDebug() << "Phomemo: No connection available (shouldn't reach here)";
+                mLastError = "No connection available";
+                return false;
+        }
+
+
+        ///
+        /// Flush data (ensure all data is sent)
+        ///
+        void BluetoothSerial::flush()
+        {
+                if ( mPort && mPort->isOpen() )
+                {
+                        mPort->flush();
+                        mPort->waitForBytesWritten( 1000 );
+                }
+
+                // Note: For Bluetooth sockets, flush is implicit with write()
+                // waitForBytesWritten() often doesn't work correctly with QBluetoothSocket
+                if ( mSocket && mSocket->isOpen() )
+                {
+                        // Just ensure the socket processes events
+                        QCoreApplication::processEvents();
+                }
+        }
+
+
+        ///
+        /// Get last error message
+        ///
+        QString BluetoothSerial::lastError() const
+        {
+                return mLastError;
+        }
+
+
+        ///
+        /// Open via existing /dev/rfcomm* device (Linux only)
+        ///
+#ifdef Q_OS_LINUX
+        bool BluetoothSerial::openViaRfcommDevice()
+        {
+                // Look for /dev/rfcomm0 through /dev/rfcomm99
+                for ( int i = 0; i < 100; i++ )
+                {
+                        QString devicePath = findRfcommDevice(i);
+
+                        // Skip if this index doesn't exist, continue to next
+                        if ( devicePath.isEmpty() )
+                        {
+                                continue;  // Try next index
+                        }
+
+                        qDebug() << "Found RFCOMM device:" << devicePath;
+
+                        mPort.reset( new QSerialPort( devicePath ) );
+                        mPort->setBaudRate( QSerialPort::Baud9600 );
+                        mPort->setDataBits( QSerialPort::Data8 );
+                        mPort->setParity( QSerialPort::NoParity );
+                        mPort->setStopBits( QSerialPort::OneStop );
+                        mPort->setFlowControl( QSerialPort::NoFlowControl );
+
+                        if ( !mPort->open( QIODevice::WriteOnly ) )
+                        {
+                                mLastError = QString("Failed to open %1: %2")
+                                             .arg( devicePath )
+                                             .arg( mPort->errorString() );
+                                mPort.reset();
+                                // Try next device
+                                continue;
+                        }
+                        else
+                        {
+                                // Successfully opened!
+                                mLastError.clear();
+                                return true;
+                        }
+                }
+
+                // Checked all 100 devices, none worked
+                mLastError = QString("No /dev/rfcomm* device found for %1")
+                             .arg( mAddress.toString() );
+                return false;
+        }
+
+
+        ///
+        /// Find /dev/rfcomm* device for this Bluetooth address
+        ///
+        QString BluetoothSerial::findRfcommDevice(int i)
+        {
+
+                QString devicePath = QString("/dev/rfcomm%1").arg(i);
+                QString sysfsPath = QString("/sys/class/tty/rfcomm%1/address").arg(i);
+
+                if ( !QFile::exists( devicePath ) )
+                {
+                        return "";
+                }
+
+                qDebug() << "Phomemo: Checking RFCOMM device:" << devicePath;
+
+                // Verify this device corresponds to our Bluetooth address
+                QFile sysfsFile( sysfsPath );
+                if ( sysfsFile.open( QIODevice::ReadOnly | QIODevice::Text ) )
+                {
+                        QString deviceAddress = QString::fromUtf8( sysfsFile.readAll().trimmed() );
+                        sysfsFile.close();
+
+                        qDebug() << "Phomemo: Device" << devicePath << "has address" << deviceAddress
+                                                << "looking for" << mAddress.toString();
+
+                        if ( deviceAddress.compare( mAddress.toString(), Qt::CaseInsensitive ) == 0 )
+                        {
+                                qDebug() << "Phomemo: Found matching RFCOMM device:" << devicePath;
+                                return devicePath;
+                        }
+                }
+                else
+                {
+                        // Sysfs not available (might not be Linux), just use first available device
+                        qDebug() << "Phomemo: Cannot verify address (sysfs unavailable), using:" << devicePath;
+                        return devicePath;
+                }
+                return "";
+        }
+#endif // Q_OS_LINUX
+
+
+        ///
+        /// Open via service discovery (discovers SPP service first)
+        ///
+        bool BluetoothSerial::openViaServiceDiscovery()
+        {
+                qDebug() << "Phomemo: Starting service discovery on" << mAddress.toString();
+
+                QBluetoothServiceDiscoveryAgent discoveryAgent;
+                discoveryAgent.setRemoteAddress( mAddress );
+
+                QEventLoop loop;
+                QTimer timer;
+                timer.setSingleShot( true );
+                QList<QBluetoothServiceInfo> foundServices;
+                bool discoveryFinished = false;
+                bool discoveryCanceled = false;
+                QString discoveryError;
+
+                QObject::connect( &discoveryAgent, &QBluetoothServiceDiscoveryAgent::serviceDiscovered,
+                                  [&foundServices]( const QBluetoothServiceInfo& info ) {
+                                          foundServices.append( info );
+                                          qDebug() << "Phomemo: Found service:" << info.serviceName()
+                                                   << "UUID:" << info.serviceUuid()
+                                                   << "Device:" << info.device().name()
+                                                   << "Protocol:" << info.socketProtocol();
+                                  });
+
+                QObject::connect( &discoveryAgent, &QBluetoothServiceDiscoveryAgent::finished,
+                                  [&loop, &discoveryFinished]() {
+                                          qDebug() << "Phomemo: Service discovery finished normally";
+                                          discoveryFinished = true;
+                                          loop.quit();
+                                  });
+
+                QObject::connect( &discoveryAgent, &QBluetoothServiceDiscoveryAgent::canceled,
+                                  [&loop, &discoveryCanceled]() {
+                                          qDebug() << "Phomemo: Service discovery was canceled";
+                                          discoveryCanceled = true;
+                                          loop.quit();
+                                  });
+
+                QObject::connect( &discoveryAgent, &QBluetoothServiceDiscoveryAgent::errorOccurred,
+                                  [&loop, &discoveryError]( QBluetoothServiceDiscoveryAgent::Error error ) {
+                                          qDebug() << "Phomemo: Service discovery error:" << error;
+                                          discoveryError = QString("Discovery error: %1").arg( error );
+                                          loop.quit();
+                                  });
+
+                QObject::connect( &timer, &QTimer::timeout, [&discoveryAgent, &loop]() {
+                        qDebug() << "Phomemo: Service discovery timeout, stopping...";
+                        discoveryAgent.stop();
+                        loop.quit();
+                });
+
+                timer.start( 30000 );  // 30 second timeout for service discovery
+                discoveryAgent.start( QBluetoothServiceDiscoveryAgent::FullDiscovery );
+                qDebug() << "Phomemo: Service discovery agent started";
+                loop.exec();
+
+                qDebug() << "Phomemo: Service discovery complete."
+                         << "Found" << foundServices.size() << "services"
+                         << "Finished:" << discoveryFinished
+                         << "Canceled:" << discoveryCanceled
+                         << "Error:" << discoveryError;
+
+                if ( !discoveryError.isEmpty() )
+                {
+                        mLastError = discoveryError;
+                        return false;
+                }
+
+                // Find SPP service
+                for ( const auto& service : foundServices )
+                {
+                        qDebug() << "Phomemo: Checking service:" << service.serviceName()
+                                 << "UUID:" << service.serviceUuid()
+                                 << "Class UUIDs:" << service.serviceClassUuids();
+
+                        // Check if this is a Serial Port Profile service
+                        if ( service.serviceUuid() == QBluetoothUuid::ServiceClassUuid::SerialPort ||
+                             service.serviceClassUuids().contains( QBluetoothUuid::ServiceClassUuid::SerialPort ) )
+                        {
+                                qDebug() << "Phomemo: Found SPP service, attempting connection...";
+                                qDebug() << "Phomemo: Service details:"
+                                         << "Name:" << service.serviceName()
+                                         << "Description:" << service.serviceDescription()
+                                         << "Provider:" << service.serviceProvider();
+
+                                mSocket.reset( new QBluetoothSocket( QBluetoothServiceInfo::RfcommProtocol ) );
+                                mSocket->connectToService( service );
+
+                                QEventLoop connLoop;
+                                QTimer connTimer;
+                                connTimer.setSingleShot( true );
+
+                                QObject::connect( mSocket.get(), &QBluetoothSocket::connected,
+                                                  [&connLoop]() {
+                                                          qDebug() << "Phomemo: Socket connected successfully";
+                                                          connLoop.quit();
+                                                  });
+
+                                QObject::connect( mSocket.get(), &QBluetoothSocket::errorOccurred,
+                                                  [this, &connLoop]( QBluetoothSocket::SocketError error ) {
+                                                          qDebug() << "Phomemo: Socket connection error:" << error
+                                                                   << mSocket->errorString();
+                                                          connLoop.quit();
+                                                  });
+
+                                QObject::connect( &connTimer, &QTimer::timeout,
+                                                  [&connLoop]() {
+                                                          qDebug() << "Phomemo: Socket connection timeout";
+                                                          connLoop.quit();
+                                                  });
+
+                                connTimer.start( 10000 );
+                                connLoop.exec();
+
+                                if ( mSocket->isOpen() )
+                                {
+                                        qDebug() << "Phomemo: Successfully connected to SPP service";
+                                        mLastError.clear();
+                                        return true;
+                                }
+                                else
+                                {
+                                        qDebug() << "Phomemo: Failed to connect to SPP service:" << mSocket->errorString();
+                                        mSocket.reset();
+                                }
+                        }
+                }
+
+                mLastError = QString("No SPP service found on device %1 (found %2 services)")
+                             .arg( mAddress.toString() )
+                             .arg( foundServices.size() );
+                return false;
+        }
+
+
+        ///
+        /// Open via QBluetoothSocket (creates new connection)
+        ///
+        bool BluetoothSerial::openViaBluetoothSocket()
+        {
+                mSocket.reset( new QBluetoothSocket( QBluetoothServiceInfo::RfcommProtocol ) );
+
+                // Connect using Serial Port Profile UUID
+                QBluetoothUuid sppUuid( QBluetoothUuid::ServiceClassUuid::SerialPort );
+                qDebug() << "Connecting to SPP UUID on" << mAddress.toString();
+                mSocket->connectToService( mAddress, sppUuid );
+
+                // Wait for connection with 10 second timeout
+                QEventLoop loop;
+                QTimer timer;
+                timer.setSingleShot( true );
+
+                QObject::connect( mSocket.get(), &QBluetoothSocket::connected,
+                                  &loop, &QEventLoop::quit );
+                QObject::connect( mSocket.get(), &QBluetoothSocket::errorOccurred,
+                                  &loop, &QEventLoop::quit );
+                QObject::connect( &timer, &QTimer::timeout,
+                                  &loop, &QEventLoop::quit );
+
+                timer.start( 10000 );
+                loop.exec();
+
+                qDebug() << "Phomemo: After event loop - socket state:" << mSocket->state()
+                         << "isOpen:" << mSocket->isOpen()
+                         << "error:" << mSocket->error()
+                         << "errorString:" << mSocket->errorString();
+
+                if ( !mSocket->isOpen() )
+                {
+                        mLastError = QString("Failed to connect via Bluetooth socket: %1")
+                                     .arg( mSocket->errorString() );
+                        qDebug() << "Connection error:" << mSocket->error() << mSocket->errorString();
+                        mSocket.reset();
+                        return false;
+                }
+
+                qDebug() << "Phomemo: Socket is open, returning true";
+                mLastError.clear();
+                return true;
+        }
+}

--- a/backends/printer/transport/BluetoothSerial.hpp
+++ b/backends/printer/transport/BluetoothSerial.hpp
@@ -1,0 +1,89 @@
+//  Printer/Transport/BluetoothSerial.hpp
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//
+//  This file is part of gLabels-qt.
+//
+//  gLabels-qt is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  gLabels-qt is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with gLabels-qt.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef printer_transport_BluetoothSerial_hpp
+#define printer_transport_BluetoothSerial_hpp
+
+
+#include <QBluetoothAddress>
+#include <QBluetoothServiceDiscoveryAgent>
+#include <QBluetoothSocket>
+#include <QSerialPort>
+#include <QString>
+#include <memory>
+
+
+namespace glabels::printer::transport
+{
+
+        ///
+        /// Bluetooth Serial Transport (RFCOMM)
+        /// Supports two modes:
+        /// 1. Use existing /dev/rfcomm* device (when connected via system Bluetooth manager)
+        /// 2. Create new QBluetoothSocket connection (when not already connected)
+        ///
+        class BluetoothSerial
+        {
+                /////////////////////////////////
+                // Life Cycle
+                /////////////////////////////////
+        public:
+                BluetoothSerial( const QBluetoothAddress& address );
+                ~BluetoothSerial();
+
+
+                /////////////////////////////////
+                // Public Methods
+                /////////////////////////////////
+        public:
+                bool open();
+                void close();
+                bool isOpen() const;
+
+                bool write( const QByteArray& data );
+                void flush();
+
+                QString lastError() const;
+
+
+                /////////////////////////////////
+                // Private Methods
+                /////////////////////////////////
+        private:
+                bool openViaRfcommDevice();
+                bool openViaBluetoothSocket();
+                bool openViaServiceDiscovery();
+                QString findRfcommDevice(int i);
+
+
+                /////////////////////////////////
+                // Private Data
+                /////////////////////////////////
+        private:
+                QBluetoothAddress                      mAddress;
+                std::unique_ptr<QSerialPort>           mPort;          // Used for /dev/rfcomm* mode
+                std::unique_ptr<QBluetoothSocket>      mSocket;        // Used for direct connection mode
+                QString                                mLastError;
+        };
+
+}
+
+
+#endif // printer_transport_BluetoothSerial_hpp

--- a/glabels/CMakeLists.txt
+++ b/glabels/CMakeLists.txt
@@ -140,9 +140,16 @@ target_include_directories (glabels-qt
 
 target_link_libraries (glabels-qt
   Model
+  Printer
   Qt6::Concurrent
   Qt6::Widgets
 )
+
+if (HAVE_BLUETOOTH_SUPPORT)
+  target_link_libraries (glabels-qt
+    Qt6::Bluetooth
+  )
+endif ()
 
 #=======================================
 # Install

--- a/glabels/PrintView.cpp
+++ b/glabels/PrintView.cpp
@@ -24,6 +24,8 @@
 #include "PrinterMonitor.hpp"
 
 #include "model/Settings.hpp"
+#include "backends/printer/Factory.hpp"
+#include "backends/printer/Backend.hpp"
 
 #include <QDebug>
 #include <QFileDialog>
@@ -50,6 +52,8 @@ namespace glabels
                 loadDestinations( printerMonitor->availablePrinters() );
                 connect( printerMonitor, SIGNAL(availablePrintersChanged(QStringList)),
                          this, SLOT(onAvailablePrintersChanged(QStringList)) );
+                connect( printerMonitor, SIGNAL(bluetoothScanningChanged(bool,bool)),
+                         this, SLOT(onBluetoothScanningChanged(bool,bool)) );
 
                 setDestination( model::Settings::recentPrinter() );
 
@@ -79,6 +83,48 @@ namespace glabels
                 auto savedSelection = destinationCombo->currentText();
                 loadDestinations( printers );
                 setDestination( savedSelection );
+        }
+
+
+        ///
+        /// Bluetooth scanning changed handler
+        ///
+        void PrintView::onBluetoothScanningChanged( bool isScanning, bool hasDevices )
+        {
+                // Find and remove any existing scanning indicator
+                for ( int i = 0; i < destinationCombo->count(); i++ )
+                {
+                        QVariant itemData = destinationCombo->itemData( i );
+                        if ( itemData.isValid() && itemData.toString() == "BT_SCANNING" )
+                        {
+                                destinationCombo->removeItem( i );
+                                break;
+                        }
+                }
+
+                // If scanning and no devices found yet, add a scanning indicator
+                if ( isScanning && !hasDevices )
+                {
+                        // Position to insert: before PDF option (which is always last)
+                        int insertPos = destinationCombo->count() - 1;
+
+                        // If there's a separator (CUPS printers exist), insert after it
+                        for ( int i = 0; i < destinationCombo->count(); i++ )
+                        {
+                                if ( destinationCombo->itemText( i ).isEmpty() ) // Separator
+                                {
+                                        insertPos = i + 1; // After separator
+                                        break;
+                                }
+                        }
+
+                        // Create a disabled item to indicate scanning
+                        QIcon icon = QIcon::fromTheme( "network-bluetooth" );
+                        destinationCombo->insertItem( insertPos, icon, tr("Searching for Bluetooth printers..."), QVariant("BT_SCANNING") );
+
+                        // Make the item look disabled but still selectable (so we can show the message)
+                        // The actual check happens in onPrintButtonClicked
+                }
         }
 
 
@@ -208,6 +254,49 @@ namespace glabels
         ///
         void PrintView::onPrintButtonClicked()
         {
+                // Get printer ID from combo box item data
+                QVariant printerData = destinationCombo->currentData();
+
+                // Check if this is the scanning indicator - ignore it
+                if ( printerData.isValid() && printerData.toString() == "BT_SCANNING" )
+                {
+                        QMessageBox::information( this, tr("Bluetooth Scanning"),
+                                tr("Bluetooth device discovery is in progress. Please wait for devices to appear.") );
+                        return;
+                }
+
+                // Check if this is a Bluetooth printer
+                if ( printerData.isValid() && printerData.toString().startsWith( "BT:" ) )
+                {
+                        // Bluetooth printer - use backend factory
+                        QString printerId = printerData.toString();
+                        auto* backend = printer::Factory::createBackend( printerId );
+
+                        if ( backend && backend->isAvailable() )
+                        {
+                                if ( backend->print( &mRenderer ) )
+                                {
+                                        // Success
+                                        model::Settings::setRecentPrinter( printerId );
+                                }
+                                else
+                                {
+                                        QMessageBox::critical( this, tr("Print Error"),
+                                                tr("Failed to print to Bluetooth device: %1")
+                                                .arg( backend->lastError() ) );
+                                }
+                        }
+                        else
+                        {
+                                QMessageBox::critical( this, tr("Print Error"),
+                                        tr("Bluetooth device not available. Ensure device is paired and powered on.") );
+                        }
+
+                        delete backend;
+                        return;
+                }
+
+                // CUPS printer or PDF
                 auto printerName = destinationCombo->currentText();
                 auto printerInfo = QPrinterInfo::printerInfo( printerName );
                 bool isPrinter = !printerInfo.isNull();
@@ -293,15 +382,47 @@ namespace glabels
                 destinationCombo->blockSignals( true );
 
                 destinationCombo->clear();
-                for ( auto& printerName : printers )
+
+                // Separate CUPS and Bluetooth printers for organized display
+                QStringList cupsPrinters;
+                QStringList bluetoothPrinters;
+
+                for ( auto& printerId : printers )
                 {
-                        destinationCombo->addItem( QIcon::fromTheme( "glabels-print" ), printerName  );
+                        if ( printerId.startsWith( "BT:" ) )
+                        {
+                                bluetoothPrinters.append( printerId );
+                        }
+                        else
+                        {
+                                cupsPrinters.append( printerId );
+                        }
                 }
 
-                if ( destinationCombo->count() )
+                // Add CUPS printers first
+                for ( auto& printerId : cupsPrinters )
+                {
+                        QIcon icon = QIcon::fromTheme( "glabels-print" );
+                        destinationCombo->addItem( icon, printerId, QVariant( printerId ) );
+                }
+
+                // Add separator if we have both types
+                if ( !cupsPrinters.isEmpty() && !bluetoothPrinters.isEmpty() )
                 {
                         destinationCombo->insertSeparator( destinationCombo->count() );
                 }
+
+                // Add Bluetooth printers
+                for ( auto& printerId : bluetoothPrinters )
+                {
+                        QIcon icon = QIcon::fromTheme( "network-bluetooth" );
+                        // Extract device name from "BT:DeviceName:MAC"
+                        QStringList parts = printerId.split( ':' );
+                        QString displayName = parts.size() > 1 ? parts[1] : printerId;
+                        destinationCombo->addItem( icon, displayName, QVariant( printerId ) );
+                }
+
+                // PDF option (no item data - we'll check for null QVariant)
                 destinationCombo->addItem( QIcon::fromTheme( "glabels-file-new" ), tr( "Print to file (PDF)" ) );
 
                 destinationCombo->blockSignals( false );

--- a/glabels/PrintView.hpp
+++ b/glabels/PrintView.hpp
@@ -58,6 +58,7 @@ namespace glabels
                 /////////////////////////////////
         private slots:
                 void onAvailablePrintersChanged( QStringList printers );
+                void onBluetoothScanningChanged( bool isScanning, bool hasDevices );
                 void onModelChanged();
                 void updateView();
                 void onFormChanged();

--- a/glabels/PrinterMonitor.cpp
+++ b/glabels/PrinterMonitor.cpp
@@ -45,6 +45,19 @@ namespace glabels
 
                 mCurrentAvailablePrinters = QPrinterInfo::availablePrinterNames();
 
+#ifdef HAVE_BLUETOOTH_SUPPORT
+                // Initialize Bluetooth device discovery
+                mBtAgent.reset( new QBluetoothDeviceDiscoveryAgent( this ) );
+                connect( mBtAgent.get(), &QBluetoothDeviceDiscoveryAgent::deviceDiscovered,
+                         this, &PrinterMonitor::onBluetoothDeviceDiscovered );
+                connect( mBtAgent.get(), &QBluetoothDeviceDiscoveryAgent::finished,
+                         this, &PrinterMonitor::onBluetoothDiscoveryFinished );
+                connect( mBtAgent.get(), QOverload<QBluetoothDeviceDiscoveryAgent::Error>::of(&QBluetoothDeviceDiscoveryAgent::errorOccurred),
+                         this, &PrinterMonitor::onBluetoothDiscoveryError );
+
+                // Don't scan immediately - let the timer handle it to avoid blocking UI startup
+#endif
+
                 mTimer.reset( new QTimer( this ) );
                 connect( mTimer.get(), SIGNAL(timeout()), this, SLOT(onTimerTimeout()) );
                 mTimer->start( 10s );
@@ -80,6 +93,11 @@ namespace glabels
         ///
         void PrinterMonitor::onTimerTimeout()
         {
+#ifdef HAVE_BLUETOOTH_SUPPORT
+                // Trigger Bluetooth scan in main thread (Qt Bluetooth requires this)
+                scanBluetoothDevices();
+#endif
+
                 // Make sure previous poll is complete before starting a new one
                 if ( mPollStatus.isFinished() )
                 {
@@ -93,16 +111,125 @@ namespace glabels
         ///
         void PrinterMonitor::asyncPoll()
         {
-                auto newAvailablePrinters = QPrinterInfo::availablePrinterNames();
-                if ( newAvailablePrinters != mCurrentAvailablePrinters )
+                // Get CUPS printers
+                auto cupsPrinters = QPrinterInfo::availablePrinterNames();
+
+                // Combine with Bluetooth printers
+                QStringList combinedPrinters = cupsPrinters;
+
+#ifdef HAVE_BLUETOOTH_SUPPORT
+                // Add Bluetooth devices with "BT:DeviceName:MAC" format
+                // (Bluetooth scanning happens in main thread via onTimerTimeout)
+                QMutexLocker btMutex( &mBtDevicesMutex );
+                for ( const auto& device : mBtDevices )
+                {
+                        QString deviceId = QString("BT:%1:%2")
+                                           .arg( device.name() )
+                                           .arg( device.address().toString() );
+                        combinedPrinters.append( deviceId );
+                }
+#endif
+
+                // Check if printer list changed
+                if ( combinedPrinters != mCurrentAvailablePrinters )
                 {
                         QMutexLocker mutex( &mCurrentAvailablePrintersMutex );
 
-                        mCurrentAvailablePrinters = newAvailablePrinters;
+                        mCurrentAvailablePrinters = combinedPrinters;
 
                         emit availablePrintersChanged( mCurrentAvailablePrinters );
                 }
         }
+
+
+
+#ifdef HAVE_BLUETOOTH_SUPPORT
+        ///
+        /// Scan for Bluetooth devices
+        ///
+        void PrinterMonitor::scanBluetoothDevices()
+        {
+                if ( mBtAgent && !mBtAgent->isActive() )
+                {
+                        // Don't clear previous results - keep already discovered devices
+                        // to avoid flickering in the UI
+
+                        // Emit scanning started signal
+                        mBtScanning = true;
+                        emit bluetoothScanningChanged( true, !mBtDevices.isEmpty() );
+
+                        // Start discovery for classic Bluetooth devices (not BLE)
+                        mBtAgent->start( QBluetoothDeviceDiscoveryAgent::ClassicMethod );
+                }
+        }
+
+
+        ///
+        /// Bluetooth device discovered slot
+        ///
+        void PrinterMonitor::onBluetoothDeviceDiscovered( const QBluetoothDeviceInfo& device )
+        {
+                // Filter for Phomemo devices
+                if ( isPhomemoDevice( device.name() ) )
+                {
+                        QMutexLocker mutex( &mBtDevicesMutex );
+
+                        // Add if not already in list
+                        bool found = false;
+                        for ( const auto& existing : mBtDevices )
+                        {
+                                if ( existing.address() == device.address() )
+                                {
+                                        found = true;
+                                        break;
+                                }
+                        }
+
+                        if ( !found )
+                        {
+                                mBtDevices.append( device );
+                                qDebug() << "Found Phomemo device:" << device.name()
+                                         << "at" << device.address().toString();
+                        }
+                }
+        }
+
+
+        ///
+        /// Check if device name indicates a Phomemo printer
+        ///
+        bool PrinterMonitor::isPhomemoDevice( const QString& name )
+        {
+                return name.startsWith( "Phomemo", Qt::CaseInsensitive ) ||
+                       name.startsWith( "D30", Qt::CaseInsensitive ) ||
+                       name.startsWith( "D35", Qt::CaseInsensitive ) ||
+                       name.startsWith( "M02", Qt::CaseInsensitive );
+        }
+
+
+        ///
+        /// Bluetooth discovery finished slot
+        ///
+        void PrinterMonitor::onBluetoothDiscoveryFinished()
+        {
+                mBtScanning = false;
+                emit bluetoothScanningChanged( false, !mBtDevices.isEmpty() );
+
+                qDebug() << "Bluetooth discovery finished. Found" << mBtDevices.size() << "Phomemo device(s).";
+        }
+
+
+        ///
+        /// Bluetooth discovery error slot
+        ///
+        void PrinterMonitor::onBluetoothDiscoveryError( QBluetoothDeviceDiscoveryAgent::Error error )
+        {
+                mBtScanning = false;
+                emit bluetoothScanningChanged( false, !mBtDevices.isEmpty() );
+
+                qDebug() << "Bluetooth discovery error:" << error;
+        }
+#endif
 
 
 } // namespace glabels

--- a/glabels/PrinterMonitor.hpp
+++ b/glabels/PrinterMonitor.hpp
@@ -28,6 +28,11 @@
 #include <QStringList>
 #include <QTimer>
 
+#ifdef HAVE_BLUETOOTH_SUPPORT
+#include <QBluetoothDeviceDiscoveryAgent>
+#include <QBluetoothDeviceInfo>
+#endif
+
 #include <memory>
 
 
@@ -64,12 +69,19 @@ namespace glabels
         private slots:
                 void onTimerTimeout();
 
+#ifdef HAVE_BLUETOOTH_SUPPORT
+                void onBluetoothDeviceDiscovered( const QBluetoothDeviceInfo& device );
+                void onBluetoothDiscoveryFinished();
+                void onBluetoothDiscoveryError( QBluetoothDeviceDiscoveryAgent::Error error );
+#endif
+
 
                 /////////////////////////////////
                 // Signals
                 /////////////////////////////////
         signals:
                 void availablePrintersChanged( QStringList availablePrinters );
+                void bluetoothScanningChanged( bool isScanning, bool hasDevices );
 
 
                 /////////////////////////////////
@@ -77,6 +89,11 @@ namespace glabels
                 /////////////////////////////////
         private:
                 void asyncPoll();
+
+#ifdef HAVE_BLUETOOTH_SUPPORT
+                void scanBluetoothDevices();
+                bool isPhomemoDevice( const QString& name );
+#endif
 
 
                 /////////////////////////////////
@@ -91,6 +108,13 @@ namespace glabels
                 QMutex      mCurrentAvailablePrintersMutex;
 
                 QFuture<void> mPollStatus;
+
+#ifdef HAVE_BLUETOOTH_SUPPORT
+                std::unique_ptr<QBluetoothDeviceDiscoveryAgent> mBtAgent;
+                QList<QBluetoothDeviceInfo>                     mBtDevices;
+                QMutex                                          mBtDevicesMutex;
+                bool                                            mBtScanning = false;
+#endif
         };
 
 }

--- a/glabels/main.cpp
+++ b/glabels/main.cpp
@@ -30,6 +30,7 @@
 
 #include "barcode/Backends.hpp"
 #include "merge/Factory.hpp"
+#include "backends/printer/Factory.hpp"
 
 #include <QApplication>
 #include <QCommandLineParser>
@@ -107,6 +108,7 @@ int main( int argc, char **argv )
         glabels::model::Db::init();
         glabels::merge::Factory::init();
         glabels::barcode::Backends::init();
+        glabels::printer::Factory::init();
 
 
         //

--- a/templates/CMakeLists.txt
+++ b/templates/CMakeLists.txt
@@ -37,6 +37,7 @@ set (template_files
   misc-us-templates.xml
   online-templates.xml
   pearl-iso-templates.xml
+  phomemo-templates.xml
   rayfilm-templates.xml
   sheetlabels-us-templates.xml
   uline-us-templates.xml

--- a/templates/phomemo-templates.xml
+++ b/templates/phomemo-templates.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0"?>
+
+<Glabels-templates>
+
+
+  <!-- ******************************************************************** -->
+  <!-- ******************************************************************** -->
+  <!--                                                                      -->
+  <!-- Phomemo Bluetooth Thermal Printer Labels                            -->
+  <!--                                                                      -->
+  <!-- Print width: 96 pixels @ 203 DPI = ~12mm (D30) or ~15mm (D35)      -->
+  <!-- These templates are optimized for Phomemo D30 and D35 printers     -->
+  <!--                                                                      -->
+  <!-- ******************************************************************** -->
+  <!-- ******************************************************************** -->
+
+
+  <!-- ===================================================================== -->
+  <!-- Phomemo D30 Labels (12mm width)                                      -->
+  <!-- ===================================================================== -->
+
+  <Template brand="Phomemo" part="D30-12x20" size="Other" _description="D30 Label 12mm x 20mm">
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Label-rectangle id="0" width="12mm" height="20mm" round="0.5mm" x_waste="0mm" y_waste="0mm">
+      <Markup-margin size="0.5mm"/>
+      <Layout nx="1" ny="1" x0="0mm" y0="0mm" dx="0mm" dy="0mm"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Phomemo" part="D30-12x30" size="Other" _description="D30 Label 12mm x 30mm">
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Label-rectangle id="0" width="12mm" height="30mm" round="0.5mm" x_waste="0mm" y_waste="0mm">
+      <Markup-margin size="0.5mm"/>
+      <Layout nx="1" ny="1" x0="0mm" y0="0mm" dx="0mm" dy="0mm"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Phomemo" part="D30-12x40" size="Other" _description="D30 Label 12mm x 40mm">
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Label-rectangle id="0" width="12mm" height="40mm" round="0.5mm" x_waste="0mm" y_waste="0mm">
+      <Markup-margin size="0.5mm"/>
+      <Layout nx="1" ny="1" x0="0mm" y0="0mm" dx="0mm" dy="0mm"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Phomemo" part="D30-12x50" size="Other" _description="D30 Label 12mm x 50mm">
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Label-rectangle id="0" width="12mm" height="50mm" round="0.5mm" x_waste="0mm" y_waste="0mm">
+      <Markup-margin size="0.5mm"/>
+      <Layout nx="1" ny="1" x0="0mm" y0="0mm" dx="0mm" dy="0mm"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Phomemo" part="D30-12x60" size="Other" _description="D30 Label 12mm x 60mm">
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Label-rectangle id="0" width="12mm" height="60mm" round="0.5mm" x_waste="0mm" y_waste="0mm">
+      <Markup-margin size="0.5mm"/>
+      <Layout nx="1" ny="1" x0="0mm" y0="0mm" dx="0mm" dy="0mm"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Phomemo" part="D30-12x80" size="Other" _description="D30 Label 12mm x 80mm">
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Label-rectangle id="0" width="12mm" height="80mm" round="0.5mm" x_waste="0mm" y_waste="0mm">
+      <Markup-margin size="0.5mm"/>
+      <Layout nx="1" ny="1" x0="0mm" y0="0mm" dx="0mm" dy="0mm"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Phomemo" part="D30-12x100" size="Other" _description="D30 Label 12mm x 100mm">
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Label-rectangle id="0" width="12mm" height="100mm" round="0.5mm" x_waste="0mm" y_waste="0mm">
+      <Markup-margin size="0.5mm"/>
+      <Layout nx="1" ny="1" x0="0mm" y0="0mm" dx="0mm" dy="0mm"/>
+    </Label-rectangle>
+  </Template>
+
+
+  <!-- ===================================================================== -->
+  <!-- Phomemo D35 Labels (15mm width)                                      -->
+  <!-- ===================================================================== -->
+
+  <Template brand="Phomemo" part="D35-15x30" size="Other" _description="D35 Label 15mm x 30mm">
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Label-rectangle id="0" width="15mm" height="30mm" round="0.5mm" x_waste="0mm" y_waste="0mm">
+      <Markup-margin size="0.5mm"/>
+      <Layout nx="1" ny="1" x0="0mm" y0="0mm" dx="0mm" dy="0mm"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Phomemo" part="D35-15x40" size="Other" _description="D35 Label 15mm x 40mm">
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Label-rectangle id="0" width="15mm" height="40mm" round="0.5mm" x_waste="0mm" y_waste="0mm">
+      <Markup-margin size="0.5mm"/>
+      <Layout nx="1" ny="1" x0="0mm" y0="0mm" dx="0mm" dy="0mm"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Phomemo" part="D35-15x50" size="Other" _description="D35 Label 15mm x 50mm">
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Label-rectangle id="0" width="15mm" height="50mm" round="0.5mm" x_waste="0mm" y_waste="0mm">
+      <Markup-margin size="0.5mm"/>
+      <Layout nx="1" ny="1" x0="0mm" y0="0mm" dx="0mm" dy="0mm"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Phomemo" part="D35-15x60" size="Other" _description="D35 Label 15mm x 60mm">
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Label-rectangle id="0" width="15mm" height="60mm" round="0.5mm" x_waste="0mm" y_waste="0mm">
+      <Markup-margin size="0.5mm"/>
+      <Layout nx="1" ny="1" x0="0mm" y0="0mm" dx="0mm" dy="0mm"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Phomemo" part="D35-15x80" size="Other" _description="D35 Label 15mm x 80mm">
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Label-rectangle id="0" width="15mm" height="80mm" round="0.5mm" x_waste="0mm" y_waste="0mm">
+      <Markup-margin size="0.5mm"/>
+      <Layout nx="1" ny="1" x0="0mm" y0="0mm" dx="0mm" dy="0mm"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Phomemo" part="D35-15x100" size="Other" _description="D35 Label 15mm x 100mm">
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Label-rectangle id="0" width="15mm" height="100mm" round="0.5mm" x_waste="0mm" y_waste="0mm">
+      <Markup-margin size="0.5mm"/>
+      <Layout nx="1" ny="1" x0="0mm" y0="0mm" dx="0mm" dy="0mm"/>
+    </Label-rectangle>
+  </Template>
+
+
+  <!-- ===================================================================== -->
+  <!-- Special Purpose Labels                                               -->
+  <!-- ===================================================================== -->
+
+  <Template brand="Phomemo" part="D30-Price-Tag" size="Other" _description="D30 Price Tag 12mm x 25mm">
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Meta category="price-tag"/>
+    <Label-rectangle id="0" width="12mm" height="25mm" round="0.5mm" x_waste="0mm" y_waste="0mm">
+      <Markup-margin size="0.5mm"/>
+      <Layout nx="1" ny="1" x0="0mm" y0="0mm" dx="0mm" dy="0mm"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Phomemo" part="D30-Name-Tag" size="Other" _description="D30 Name Tag 12mm x 35mm">
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Meta category="name-badge"/>
+    <Label-rectangle id="0" width="12mm" height="35mm" round="0.5mm" x_waste="0mm" y_waste="0mm">
+      <Markup-margin size="0.5mm"/>
+      <Layout nx="1" ny="1" x0="0mm" y0="0mm" dx="0mm" dy="0mm"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Phomemo" part="D30-Cable-Label" size="Other" _description="D30 Cable Label 12mm x 45mm">
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Label-rectangle id="0" width="12mm" height="45mm" round="0.5mm" x_waste="0mm" y_waste="0mm">
+      <Markup-margin size="0.5mm"/>
+      <Layout nx="1" ny="1" x0="0mm" y0="0mm" dx="0mm" dy="0mm"/>
+    </Label-rectangle>
+  </Template>
+
+
+</Glabels-templates>

--- a/templates/vendors.xml
+++ b/templates/vendors.xml
@@ -39,6 +39,7 @@
   <Vendor name="OfficeMax"          url="http://www.officemax.com/office-supplies/paper"/>
   <Vendor name="Online Labels"      url="http://www.onlinelabels.com/"/>
   <Vendor name="PEARL"              url="http://www.pearl.de/"/>
+  <Vendor name="Phomemo"            url="https://www.phomemo.com/"/>
   <Vendor name="Pressit"            url="http://www.pressit.com/label-applicator-systems.html"/>
   <Vendor name="Poundland"          url="http://www.poundland.co.uk/"/>
   <Vendor name="Q_CONNECT"          url="http://www.q-connect.com/"/>

--- a/translations/glabels_C.ts
+++ b/translations/glabels_C.ts
@@ -236,6 +236,14 @@
         <source>Text: Semicolon Separated Values, keys on line 1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Qt Printer System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Phomemo Bluetooth Printer</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Frame</name>
@@ -2122,7 +2130,31 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Searching for Bluetooth printers...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>(Will print a total of %1 items on 1 page.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bluetooth Scanning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bluetooth device discovery is in progress. Please wait for devices to appear.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Print Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to print to Bluetooth device: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bluetooth device not available. Ensure device is paired and powered on.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/templates_C.ts
+++ b/translations/templates_C.ts
@@ -108,6 +108,70 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>D30 Cable Label 12mm x 45mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D30 Label 12mm x 100mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D30 Label 12mm x 20mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D30 Label 12mm x 30mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D30 Label 12mm x 40mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D30 Label 12mm x 50mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D30 Label 12mm x 60mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D30 Label 12mm x 80mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D30 Name Tag 12mm x 35mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D30 Price Tag 12mm x 25mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D35 Label 15mm x 100mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D35 Label 15mm x 30mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D35 Label 15mm x 40mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D35 Label 15mm x 50mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D35 Label 15mm x 60mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D35 Label 15mm x 80mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>DLT labels</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
- Add support for Phomemo D30/D35 Bluetooth protocol.
- Add Phomemo label templates.
- Update printing UI for Bluetooth scanning.

The code should be generic enough that adding support for more Epson ESC/POS protocol printers will be easy. That protocol is custom, so these printers aren't usable through regular print drivers or system tools.

Fixes #299