### PR TITLE
Add hint to README.md about unofficial Fedora package

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ There are currently no official releases of gLabels 4.
 
 Currently there are no self-hosted binary snapshot releases available.  I plan to make these available again once 4.0 is more imminent.  In the mean time, I encourage you to try building the code yourself.
 
-Some third-party packages may be available available:
+Some third-party packages may be available:
 
 
 | Platform  | Files                                                                                | Notes                                                         |
 |:----------|:-------------------------------------------------------------------------------------|:--------------------------------------------------------------|
 | Archlinux | [Archlinux User Repository Page](https://aur.archlinux.org/packages/glabels-qt-git/) | Maintained by [Maud Spierings](https://github.com/SpieringsAE) |
 | Ubuntu    | [PPA Page](https://code.launchpad.net/~krisives/+archive/ubuntu/glabels-qt)          | Maintained by [Kristopher Ives](https://github.com/krisives)  |
+| Fedora    | [Copr Repository Page](https://copr.fedorainfracloud.org/coprs/mariobl/glabels-qt/)  | Maintained by [Mario Blättermann](https://github.com/mariobl) |
 
 
 


### PR DESCRIPTION
I'm succeded to build glabels-qt for Fedora from a Git checkout. Actually no problem, but Fedora has some pitfalls in its packaging and versioning guidelines. The package should get proper upgrade paths for future versions. I will maintain it in the Copr repository until v4.0 has been released and packaged for Fedora.