### PR TITLE
Add ALL Brother DK label templates

### DIFF
--- a/templates/brother-other-templates.xml
+++ b/templates/brother-other-templates.xml
@@ -78,7 +78,7 @@
     <Meta category="round-label"/>
     <Meta category="media"/>
     <Label-round id="0" radius="29.15mm" waste="0">
-      <Markup-circle x0="58.3mm" y0="58.3mm" radius="58.3mm" /> <!-- Print Area -->
+      <Markup-circle x0="29.15mm" y0="29.15mm" radius="29.15mm" /> <!-- Print Area -->
       <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
     </Label-round>
   </Template>

--- a/templates/brother-other-templates.xml
+++ b/templates/brother-other-templates.xml
@@ -23,9 +23,10 @@
   <!-- Die-cut Labels                                                        -->
   <!-- ********************************************************************* -->
 
-  <Template brand="Brother" part="DK-1201" _description="Address labels"
+  <Template brand="Brother" part="DK-11201" _description="Address labels"
 	    size="roll" roll_width="32mm" width="28.96mm" height="89.83mm" >
     <Meta category="label"/>
+    <Meta category="rectangle-label"/>
     <Meta category="mail"/>
     <Label-rectangle id="0" width="28.96mm" height="89.83mm" round="1.5mm" x_waste="0" y_waste="0">
       <Markup-margin x_size="1.5mm" y_size="3.0mm" /> <!-- Print Area -->
@@ -33,9 +34,12 @@
     </Label-rectangle>
   </Template>
 
-  <Template brand="Brother" part="DK-1202" _description="Shipping labels"
+  <Template brand="Brother" part="DK-1201" equiv="DK-11201"/>
+
+  <Template brand="Brother" part="DK-11202" _description="Shipping labels"
 	    size="roll" roll_width="67mm" width="61.98mm" height="99.82mm" >
     <Meta category="label"/>
+    <Meta category="rectangle-label"/>
     <Meta category="mail"/>
     <Label-rectangle id="0" width="61.98mm" height="99.82mm" round="1.5mm" x_waste="0" y_waste="0">
       <Markup-margin x_size="1.5mm" y_size="3.0mm" /> <!-- Print Area -->
@@ -43,20 +47,111 @@
     </Label-rectangle>
   </Template>
 
-  <Template brand="Brother" part="DK-1204" _description="Multipurpose labels"
+  <Template brand="Brother" part="DK-1202" equiv="DK-11202"/>
+
+  <Template brand="Brother" part="DK-11203" _description="Arch file labels"
+	    size="roll" roll_width="20mm" width="17.02mm" height="86.9mm" >
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Meta category="filing"/>
+    <Label-rectangle id="0" width="17.02mm" height="86.9mm" round="1.5mm" x_waste="0" y_waste="0">
+      <Markup-margin x_size="1.5mm" y_size="3.0mm" /> <!-- Print Area -->
+      <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Brother" part="DK-11204" _description="Multipurpose labels"
 	    size="roll" roll_width="20mm" width="17.02mm" height="53.85mm" >
     <Meta category="label"/>
+    <Meta category="rectangle-label"/>
     <Label-rectangle id="0" width="17.02mm" height="53.85mm" round="1.5mm" x_waste="0" y_waste="0">
       <Markup-margin x_size="1.5mm" y_size="3.0mm" /> <!-- Print Area -->
       <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
     </Label-rectangle>
   </Template>
 
-  <Template brand="Brother" part="DK-1208" _description="Address labels"
+  <Template brand="Brother" part="DK-1204" equiv="DK-11204"/>
+
+  <Template brand="Brother" part="DK-11207" _description="CD/DVD labels (disc labels)"
+	    size="roll" roll_width="67mm" width="58.3mm" height="58.3mm" >
+    <Meta category="label"/>
+    <Meta category="round-label"/>
+    <Meta category="media"/>
+    <Label-round id="0" radius="29.15mm" waste="0">
+      <Markup-circle x0="58.3mm" y0="58.3mm" radius="58.3mm" /> <!-- Print Area -->
+      <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
+    </Label-round>
+  </Template>
+
+  <Template brand="Brother" part="DK-11208" _description="Address labels"
 	    size="roll" roll_width="43mm" width="38.01mm" height="89.83mm" >
     <Meta category="label"/>
     <Meta category="mail"/>
     <Label-rectangle id="0" width="38.01mm" height="89.83mm" round="1.5mm" x_waste="0" y_waste="0">
+      <Markup-margin x_size="1.5mm" y_size="3.0mm" /> <!-- Print Area -->
+      <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Brother" part="DK-1208" equiv="DK-11208"/>
+
+  <Template brand="Brother" part="DK-11209" _description="Address labels"
+	    size="roll" roll_width="67mm" width="61.98mm" height="28.96mm" >
+    <Meta category="label"/>
+    <Meta category="mail"/>
+    <Label-rectangle id="0" width="61.98mm" height="28.96mm" round="1.5mm" x_waste="0" y_waste="0">
+      <Markup-margin x_size="1.5mm" y_size="3.0mm" /> <!-- Print Area -->
+      <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Brother" part="DK-11218" _description="Round labels"
+	    size="roll" roll_width="32mm" width="24mm" height="24mm" >
+    <Meta category="label"/>
+    <Meta category="round-label"/>
+    <Label-round id="0" radius="12mm" waste="0">
+      <Markup-circle x0="12mm" y0="12mm" radius="12mm" /> <!-- Print Area -->
+      <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
+    </Label-round>
+  </Template>
+
+  <Template brand="Brother" part="DK-11219" _description="Round labels"
+	    size="roll" roll_width="20mm" width="12mm" height="12mm" >
+    <Meta category="label"/>
+    <Meta category="round-label"/>
+    <Label-round id="0" radius="6mm" waste="0">
+      <Markup-circle x0="6mm" y0="6mm" radius="6mm" /> <!-- Print Area -->
+      <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
+    </Label-round>
+  </Template>
+
+  <Template brand="Brother" part="DK-11221" _description="Square labels"
+	    size="roll" roll_width="32mm" width="23mm" height="23mm" >
+    <Meta category="label"/>
+    <Meta category="square-label"/>
+    <Label-rectangle id="0" width="23mm" height="23mm" round="1.5mm" x_waste="0" y_waste="0">
+      <Markup-margin x_size="1.5mm" y_size="3.0mm" /> <!-- Print Area -->
+      <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Brother" part="DK-11240" _description="Shipping labels"
+	    size="roll" roll_width="108mm" width="102mm" height="51mm" >
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Meta category="mail"/>
+    <Label-rectangle id="0" width="102mm" height="51mm" round="1.5mm" x_waste="0" y_waste="0">
+      <Markup-margin x_size="1.5mm" y_size="3.0mm" /> <!-- Print Area -->
+      <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
+    </Label-rectangle>
+  </Template>
+
+  <Template brand="Brother" part="DK-11247" _description="Shipping labels"
+	    size="roll" roll_width="108mm" width="103mm" height="164mm" >
+    <Meta category="label"/>
+    <Meta category="rectangle-label"/>
+    <Meta category="mail"/>
+    <Label-rectangle id="0" width="103mm" height="164mm" round="1.5mm" x_waste="0" y_waste="0">
       <Markup-margin x_size="1.5mm" y_size="3.0mm" /> <!-- Print Area -->
       <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
     </Label-rectangle>
@@ -67,11 +162,87 @@
   <!-- Continuous Label Tapes                                                -->
   <!-- ********************************************************************* -->
 
-  <Template brand="Brother" part="DK-2205" _description="Continuous label tape"
+  <Template brand="Brother" part="DK-22205" _description="Continuous label tape"
 	    size="roll" roll_width="67mm" width="61.98mm" >
     <Meta category="label"/>
     <Meta category="mail"/>
+    <Meta category="filing"/>
     <Label-continuous id="0" width="61.98mm" min_height="25mm" max_height="1000mm" default_height="100mm" >
+      <Markup-margin x_size="1.5mm" y_size="3.0mm" />
+      <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
+    </Label-continuous>
+  </Template>
+
+  <Template brand="Brother" part="DK-22113" equiv="DK-22205"/>
+  <Template brand="Brother" part="DK-22212" equiv="DK-22205"/>
+  <Template brand="Brother" part="DK-22251" equiv="DK-22205"/>
+  <Template brand="Brother" part="DK-22606" equiv="DK-22205"/>
+  <Template brand="Brother" part="DK-44205" equiv="DK-22205"/>
+  <Template brand="Brother" part="DK-44605" equiv="DK-22205"/>
+
+  <Template brand="Brother" part="DK-22210" _description="Continuous label tape"
+	    size="roll" roll_width="32mm" width="28.96mm" >
+    <Meta category="label"/>
+    <Meta category="mail"/>
+    <Meta category="filing"/>
+    <Label-continuous id="0" width="28.96mm" min_height="25mm" max_height="1000mm" default_height="100mm" >
+      <Markup-margin x_size="1.5mm" y_size="3.0mm" />
+      <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
+    </Label-continuous>
+  </Template>
+
+  <Template brand="Brother" part="DK-22211" equiv="DK-22210"/>
+
+  <Template brand="Brother" part="DK-22214" _description="Continuous label tape"
+	    size="roll" roll_width="20mm" width="12mm" >
+    <Meta category="label"/>
+    <Meta category="mail"/>
+    <Meta category="filing"/>
+    <Label-continuous id="0" width="12mm" min_height="25mm" max_height="1000mm" default_height="100mm" >
+      <Markup-margin x_size="1.5mm" y_size="3.0mm" />
+      <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
+    </Label-continuous>
+  </Template>
+
+  <Template brand="Brother" part="DK-22223" _description="Continuous label tape"
+	    size="roll" roll_width="67mm" width="50mm" >
+    <Meta category="label"/>
+    <Meta category="mail"/>
+    <Meta category="filing"/>
+    <Label-continuous id="0" width="50mm" min_height="25mm" max_height="1000mm" default_height="100mm" >
+      <Markup-margin x_size="1.5mm" y_size="3.0mm" />
+      <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
+    </Label-continuous>
+  </Template>
+
+  <Template brand="Brother" part="DK-22225" _description="Continuous label tape"
+	    size="roll" roll_width="43mm" width="38.01mm" >
+    <Meta category="label"/>
+    <Meta category="mail"/>
+    <Meta category="filing"/>
+    <Label-continuous id="0" width="38.01mm" min_height="25mm" max_height="1000mm" default_height="100mm" >
+      <Markup-margin x_size="1.5mm" y_size="3.0mm" />
+      <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
+    </Label-continuous>
+  </Template>
+
+  <Template brand="Brother" part="DK-22246" _description="Continuous label tape"
+	    size="roll" roll_width="108mm" width="103mm" >
+    <Meta category="label"/>
+    <Meta category="mail"/>
+    <Meta category="filing"/>
+    <Label-continuous id="0" width="103mm" min_height="25mm" max_height="1000mm" default_height="100mm" >
+      <Markup-margin x_size="1.5mm" y_size="3.0mm" />
+      <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
+    </Label-continuous>
+  </Template>
+
+  <Template brand="Brother" part="DK-N44224" _description="Continuous label tape"
+	    size="roll" roll_width="67mm" width="54mm" >
+    <Meta category="label"/>
+    <Meta category="mail"/>
+    <Meta category="filing"/>
+    <Label-continuous id="0" width="54mm" min_height="25mm" max_height="1000mm" default_height="100mm" >
       <Markup-margin x_size="1.5mm" y_size="3.0mm" />
       <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
     </Label-continuous>

--- a/templates/brother-other-templates.xml
+++ b/templates/brother-other-templates.xml
@@ -24,11 +24,11 @@
   <!-- ********************************************************************* -->
 
   <Template brand="Brother" part="DK-11201" _description="Address labels"
-	    size="roll" roll_width="32mm" width="28.96mm" height="89.83mm" >
+	    size="roll" roll_width="32mm" width="29mm" height="90mm" >
     <Meta category="label"/>
     <Meta category="rectangle-label"/>
     <Meta category="mail"/>
-    <Label-rectangle id="0" width="28.96mm" height="89.83mm" round="1.5mm" x_waste="0" y_waste="0">
+    <Label-rectangle id="0" width="29mm" height="90mm" round="1.5mm" x_waste="0" y_waste="0">
       <Markup-margin x_size="1.5mm" y_size="3.0mm" /> <!-- Print Area -->
       <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
     </Label-rectangle>
@@ -37,11 +37,11 @@
   <Template brand="Brother" part="DK-1201" equiv="DK-11201"/>
 
   <Template brand="Brother" part="DK-11202" _description="Shipping labels"
-	    size="roll" roll_width="67mm" width="61.98mm" height="99.82mm" >
+	    size="roll" roll_width="67mm" width="62mm" height="100mm" >
     <Meta category="label"/>
     <Meta category="rectangle-label"/>
     <Meta category="mail"/>
-    <Label-rectangle id="0" width="61.98mm" height="99.82mm" round="1.5mm" x_waste="0" y_waste="0">
+    <Label-rectangle id="0" width="62mm" height="100mm" round="1.5mm" x_waste="0" y_waste="0">
       <Markup-margin x_size="1.5mm" y_size="3.0mm" /> <!-- Print Area -->
       <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
     </Label-rectangle>
@@ -50,21 +50,21 @@
   <Template brand="Brother" part="DK-1202" equiv="DK-11202"/>
 
   <Template brand="Brother" part="DK-11203" _description="Arch file labels"
-	    size="roll" roll_width="20mm" width="17.02mm" height="86.9mm" >
+	    size="roll" roll_width="20mm" width="17mm" height="87mm" >
     <Meta category="label"/>
     <Meta category="rectangle-label"/>
     <Meta category="filing"/>
-    <Label-rectangle id="0" width="17.02mm" height="86.9mm" round="1.5mm" x_waste="0" y_waste="0">
+    <Label-rectangle id="0" width="17mm" height="87mm" round="1.5mm" x_waste="0" y_waste="0">
       <Markup-margin x_size="1.5mm" y_size="3.0mm" /> <!-- Print Area -->
       <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
     </Label-rectangle>
   </Template>
 
   <Template brand="Brother" part="DK-11204" _description="Multipurpose labels"
-	    size="roll" roll_width="20mm" width="17.02mm" height="53.85mm" >
+	    size="roll" roll_width="20mm" width="17mm" height="54mm" >
     <Meta category="label"/>
     <Meta category="rectangle-label"/>
-    <Label-rectangle id="0" width="17.02mm" height="53.85mm" round="1.5mm" x_waste="0" y_waste="0">
+    <Label-rectangle id="0" width="17mm" height="54mm" round="1.5mm" x_waste="0" y_waste="0">
       <Markup-margin x_size="1.5mm" y_size="3.0mm" /> <!-- Print Area -->
       <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
     </Label-rectangle>
@@ -73,21 +73,21 @@
   <Template brand="Brother" part="DK-1204" equiv="DK-11204"/>
 
   <Template brand="Brother" part="DK-11207" _description="CD/DVD labels (disc labels)"
-	    size="roll" roll_width="67mm" width="58.3mm" height="58.3mm" >
+	    size="roll" roll_width="67mm" width="58mm" height="58mm" >
     <Meta category="label"/>
     <Meta category="round-label"/>
     <Meta category="media"/>
-    <Label-round id="0" radius="29.15mm" waste="0">
-      <Markup-circle x0="29.15mm" y0="29.15mm" radius="29.15mm" /> <!-- Print Area -->
+    <Label-round id="0" radius="29mm" waste="0">
+      <Markup-circle x0="29mm" y0="29mm" radius="29mm" /> <!-- Print Area -->
       <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
     </Label-round>
   </Template>
 
   <Template brand="Brother" part="DK-11208" _description="Address labels"
-	    size="roll" roll_width="43mm" width="38.01mm" height="89.83mm" >
+	    size="roll" roll_width="43mm" width="38mm" height="90mm" >
     <Meta category="label"/>
     <Meta category="mail"/>
-    <Label-rectangle id="0" width="38.01mm" height="89.83mm" round="1.5mm" x_waste="0" y_waste="0">
+    <Label-rectangle id="0" width="38mm" height="90mm" round="1.5mm" x_waste="0" y_waste="0">
       <Markup-margin x_size="1.5mm" y_size="3.0mm" /> <!-- Print Area -->
       <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
     </Label-rectangle>
@@ -96,10 +96,10 @@
   <Template brand="Brother" part="DK-1208" equiv="DK-11208"/>
 
   <Template brand="Brother" part="DK-11209" _description="Address labels"
-	    size="roll" roll_width="67mm" width="61.98mm" height="28.96mm" >
+	    size="roll" roll_width="67mm" width="62mm" height="29mm" >
     <Meta category="label"/>
     <Meta category="mail"/>
-    <Label-rectangle id="0" width="61.98mm" height="28.96mm" round="1.5mm" x_waste="0" y_waste="0">
+    <Label-rectangle id="0" width="62mm" height="29mm" round="1.5mm" x_waste="0" y_waste="0">
       <Markup-margin x_size="1.5mm" y_size="3.0mm" /> <!-- Print Area -->
       <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
     </Label-rectangle>
@@ -163,11 +163,11 @@
   <!-- ********************************************************************* -->
 
   <Template brand="Brother" part="DK-22205" _description="Continuous label tape"
-	    size="roll" roll_width="67mm" width="61.98mm" >
+	    size="roll" roll_width="67mm" width="62mm" >
     <Meta category="label"/>
     <Meta category="mail"/>
     <Meta category="filing"/>
-    <Label-continuous id="0" width="61.98mm" min_height="25mm" max_height="1000mm" default_height="100mm" >
+    <Label-continuous id="0" width="62mm" min_height="25mm" max_height="1000mm" default_height="100mm" >
       <Markup-margin x_size="1.5mm" y_size="3.0mm" />
       <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
     </Label-continuous>
@@ -181,11 +181,11 @@
   <Template brand="Brother" part="DK-44605" equiv="DK-22205"/>
 
   <Template brand="Brother" part="DK-22210" _description="Continuous label tape"
-	    size="roll" roll_width="32mm" width="28.96mm" >
+	    size="roll" roll_width="32mm" width="29mm" >
     <Meta category="label"/>
     <Meta category="mail"/>
     <Meta category="filing"/>
-    <Label-continuous id="0" width="28.96mm" min_height="25mm" max_height="1000mm" default_height="100mm" >
+    <Label-continuous id="0" width="29mm" min_height="25mm" max_height="1000mm" default_height="100mm" >
       <Markup-margin x_size="1.5mm" y_size="3.0mm" />
       <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
     </Label-continuous>
@@ -216,11 +216,11 @@
   </Template>
 
   <Template brand="Brother" part="DK-22225" _description="Continuous label tape"
-	    size="roll" roll_width="43mm" width="38.01mm" >
+	    size="roll" roll_width="43mm" width="38mm" >
     <Meta category="label"/>
     <Meta category="mail"/>
     <Meta category="filing"/>
-    <Label-continuous id="0" width="38.01mm" min_height="25mm" max_height="1000mm" default_height="100mm" >
+    <Label-continuous id="0" width="38mm" min_height="25mm" max_height="1000mm" default_height="100mm" >
       <Markup-margin x_size="1.5mm" y_size="3.0mm" />
       <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
     </Label-continuous>


### PR DESCRIPTION
Hey there, nice software!

I saw that there are missing labels for the Brother QL series label printers, so I added them all according to this [datasheet](https://www.brother.dk/-/media/pdf/eu/labelling/dk-label-roll/dk-roll-test-leaflet-2022.pdf?rev=-1#page=10). I also took some of the missing data from #195 and formatted it according to the template style guide.

(I'm not sure why the existing templates even differs from the manufacturer's datasheet, but I decided to keep the existing dimensions.)

Also, I renamed the existing ones as there was a naming mismatch (DK-11201 was called DK-1201, for example), but kept an alias/equiv for compatibility purposes. Also addresses #202.

I obviously don't have all the label variants, so I kept the values of existing templates and used the official datasheet to fill in the missing ones. Hope this is fine.

bliepp