### PR TITLE
Print directly to Brother P-Touch USB devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ find_package (ZLIB 1.2 QUIET)
 find_package (GnuBarcode 0.98 QUIET)
 find_package (LibQrencode 3.4 QUIET)
 find_package (LibZint 2.15 QUIET)
+find_package (LibUSB1 QUIET)
 # Unit testing support
 find_package (Qt5Test 5.6 QUIET)
 
@@ -219,6 +220,12 @@ if (LIBZINT_FOUND)
 else (LIBZINT_FOUND)
   message (STATUS "libzint (optional)....... No.")
 endif (LIBZINT_FOUND)
+
+if (LibUSB1_FOUND)
+  message (STATUS "libusb-1.0 (optional).... " ${LibUSB1_VERSION} " (P-Touch USB printing enabled)")
+else ()
+  message (STATUS "libusb-1.0 (optional).... Not found. P-Touch direct USB printing disabled.")
+endif ()
 
 if (MSVC)
    message (STATUS "MSVC Qt location ........ " ${QT_BASE_DIR})

--- a/cmake/Modules/FindLibUSB1.cmake
+++ b/cmake/Modules/FindLibUSB1.cmake
@@ -1,0 +1,48 @@
+# FindLibUSB1.cmake
+#
+# Locate libusb-1.0 via pkg-config.
+#
+# Imported targets:
+#   LibUSB1::LibUSB1   (when found)
+#
+# Result variables:
+#   LibUSB1_FOUND
+#   LibUSB1_VERSION
+#   LibUSB1_INCLUDE_DIRS
+#   LibUSB1_LIBRARIES
+
+find_package(PkgConfig QUIET)
+
+if(PkgConfig_FOUND)
+    pkg_check_modules(PC_LIBUSB1 QUIET libusb-1.0)
+endif()
+
+find_path(LibUSB1_INCLUDE_DIR
+    NAMES libusb.h
+    HINTS ${PC_LIBUSB1_INCLUDEDIR}
+    PATH_SUFFIXES libusb-1.0
+)
+
+find_library(LibUSB1_LIBRARY
+    NAMES usb-1.0 usb
+    HINTS ${PC_LIBUSB1_LIBDIR}
+)
+
+set(LibUSB1_VERSION "${PC_LIBUSB1_VERSION}")
+set(LibUSB1_INCLUDE_DIRS "${LibUSB1_INCLUDE_DIR}")
+set(LibUSB1_LIBRARIES    "${LibUSB1_LIBRARY}")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibUSB1
+    REQUIRED_VARS LibUSB1_LIBRARY LibUSB1_INCLUDE_DIR
+    VERSION_VAR   LibUSB1_VERSION
+)
+mark_as_advanced(LibUSB1_INCLUDE_DIR LibUSB1_LIBRARY)
+
+if(LibUSB1_FOUND AND NOT TARGET LibUSB1::LibUSB1)
+    add_library(LibUSB1::LibUSB1 UNKNOWN IMPORTED)
+    set_target_properties(LibUSB1::LibUSB1 PROPERTIES
+        IMPORTED_LOCATION             "${LibUSB1_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${LibUSB1_INCLUDE_DIR}"
+    )
+endif()

--- a/glabels/CMakeLists.txt
+++ b/glabels/CMakeLists.txt
@@ -1,6 +1,25 @@
 project (glabels LANGUAGES CXX)
 
 #=======================================
+# P-Touch USB backend (optional)
+#=======================================
+set (ptouch_sources
+  ptouch/UsbTransport.cpp
+  ptouch/Device.cpp
+  ptouch/Printer.cpp
+  ptouch/DeviceMonitor.cpp
+)
+
+set (ptouch_qobject_headers
+  ptouch/Printer.hpp
+  ptouch/DeviceMonitor.hpp
+)
+
+if (LibUSB1_FOUND)
+  add_definitions (-DHAVE_LIBUSB=1)
+endif ()
+
+#=======================================
 # Sources
 #=======================================
 set (glabels_sources
@@ -42,6 +61,7 @@ set (glabels_sources
   TemplatePickerItem.cpp
   UndoRedoModel.cpp
   VariablesView.cpp
+  ${ptouch_sources}
 )
 
 set (glabels_qobject_headers
@@ -110,7 +130,7 @@ set (glabels_resource_files
   images.qrc
 )
 
-qt6_wrap_cpp (glabels_moc_sources ${glabels_qobject_headers})
+qt6_wrap_cpp (glabels_moc_sources ${glabels_qobject_headers} ${ptouch_qobject_headers})
 qt6_wrap_ui (glabels_forms_headers ${glabels_forms})
 qt6_add_resources (glabels_qrc_sources ${glabels_resource_files})
 
@@ -143,6 +163,10 @@ target_link_libraries (glabels-qt
   Qt6::Concurrent
   Qt6::Widgets
 )
+
+if (LibUSB1_FOUND)
+  target_link_libraries (glabels-qt LibUSB1::LibUSB1)
+endif ()
 
 #=======================================
 # Install

--- a/glabels/PrintView.cpp
+++ b/glabels/PrintView.cpp
@@ -23,6 +23,10 @@
 
 #include "PrinterMonitor.hpp"
 
+#include "ptouch/Device.hpp"
+#include "ptouch/DeviceMonitor.hpp"
+#include "ptouch/Printer.hpp"
+
 #include "model/Settings.hpp"
 
 #include <QDebug>
@@ -51,6 +55,12 @@ namespace glabels
                 connect( printerMonitor, SIGNAL(availablePrintersChanged(QStringList)),
                          this, SLOT(onAvailablePrintersChanged(QStringList)) );
 
+                // Wire up P-Touch USB device discovery
+                auto* ptouchMonitor = ptouch::DeviceMonitor::instance();
+                loadPtouchDestinations( ptouchMonitor->availableDevices() );
+                connect( ptouchMonitor, &ptouch::DeviceMonitor::availableDevicesChanged,
+                         this, &PrintView::onAvailablePtouchDevicesChanged );
+
                 setDestination( model::Settings::recentPrinter() );
 
                 preview->setRenderer( &mRenderer );
@@ -78,6 +88,19 @@ namespace glabels
         {
                 auto savedSelection = destinationCombo->currentText();
                 loadDestinations( printers );
+                loadPtouchDestinations( ptouch::DeviceMonitor::instance()->availableDevices() );
+                setDestination( savedSelection );
+        }
+
+
+        ///
+        /// Available P-Touch devices changed handler
+        ///
+        void PrintView::onAvailablePtouchDevicesChanged( QList<ptouch::UsbDeviceId> devices )
+        {
+                auto savedSelection = destinationCombo->currentText();
+                loadDestinations( PrinterMonitor::instance()->availablePrinters() );
+                loadPtouchDestinations( devices );
                 setDestination( savedSelection );
         }
 
@@ -213,18 +236,27 @@ namespace glabels
         ///
         void PrintView::onPrintButtonClicked()
         {
-                auto printerName = destinationCombo->currentText();
-                auto printerInfo = QPrinterInfo::printerInfo( printerName );
-                bool isPrinter = !printerInfo.isNull();
+                auto selectedName = destinationCombo->currentText();
+
+                // ── P-Touch direct USB path ──────────────────────────────────────────
+                if ( ptouch::DeviceMonitor::instance()->findByDisplayName(selectedName) )
+                {
+                        printToPtouch( selectedName );
+                        return;
+                }
+
+                // ── System printer / PDF path ────────────────────────────────────────
+                auto printerInfo = QPrinterInfo::printerInfo( selectedName );
+                bool isPrinter   = !printerInfo.isNull();
 
                 QPrinter printer( QPrinter::HighResolution );
                 printer.setColorMode( QPrinter::Color );
 
                 if ( isPrinter )
                 {
-                        printer.setPrinterName( printerName );
+                        printer.setPrinterName( selectedName );
                         mRenderer.print( &printer );
-                        model::Settings::setRecentPrinter( printerName );
+                        model::Settings::setRecentPrinter( selectedName );
                 }
                 else
                 {
@@ -262,6 +294,75 @@ namespace glabels
 
 
         ///
+        /// Print to a P-Touch device directly over USB.
+        ///
+        bool PrintView::printToPtouch( const QString& deviceDisplayName )
+        {
+                auto idOpt = ptouch::DeviceMonitor::instance()->findByDisplayName( deviceDisplayName );
+                if ( !idOpt )
+                {
+                        QMessageBox::critical( this, tr("P-Touch Print Error"),
+                                               tr("Device \"%1\" is no longer connected.").arg(deviceDisplayName) );
+                        return false;
+                }
+
+                QString openError;
+                auto device = ptouch::Device::open(
+                    ptouch::DeviceMonitor::instance()->usbContext(), *idOpt, openError);
+
+                if ( !device )
+                {
+                        QMessageBox::critical( this, tr("P-Touch Print Error"),
+                                               tr("Could not open device:\n%1").arg(openError) );
+                        return false;
+                }
+
+                ptouch::DeviceStatus status;
+                QString statusError;
+                if ( !device->queryStatus(status, statusError) )
+                {
+                        QMessageBox::critical( this, tr("P-Touch Print Error"),
+                                               tr("Could not read printer status:\n%1").arg(statusError) );
+                        return false;
+                }
+
+                if ( status.hasError() )
+                {
+                        QMessageBox::warning( this, tr("P-Touch"),
+                                              tr("Printer reports an error (code 0x%1).  "
+                                                 "Check that tape is loaded and the cover is closed.")
+                                              .arg(status.errorCode, 4, 16, QLatin1Char('0')) );
+                }
+
+                ptouch::Printer printer( *device, status, this );
+
+                // Show a simple progress dialog while printing
+                QMessageBox progress( this );
+                progress.setWindowTitle( tr("Printing…") );
+                progress.setText( tr("Sending %1 label(s) to %2…")
+                                   .arg(mRenderer.nItems())
+                                   .arg(device->displayName()) );
+                progress.setStandardButtons( QMessageBox::NoButton );
+                progress.show();
+                QCoreApplication::processEvents();
+
+                bool ok = printer.print( mRenderer );
+
+                progress.hide();
+
+                if ( !ok )
+                {
+                        QMessageBox::critical( this, tr("P-Touch Print Error"),
+                                               printer.lastError() );
+                        return false;
+                }
+
+                model::Settings::setRecentPrinter( deviceDisplayName );
+                return true;
+        }
+
+
+        ///
         /// System Dialog Button Clicked handler
         ///
         void PrintView::onSystemDialogButtonClicked()
@@ -291,7 +392,7 @@ namespace glabels
 
 
         ///
-        /// Load available printers
+        /// Load available printers (system spooler)
         ///
         void PrintView::loadDestinations( const QStringList& printers )
         {
@@ -308,6 +409,35 @@ namespace glabels
                         destinationCombo->insertSeparator( destinationCombo->count() );
                 }
                 destinationCombo->addItem( QIcon::fromTheme( "glabels-file-new" ), tr( "Print to file (PDF)" ) );
+
+                destinationCombo->blockSignals( false );
+        }
+
+
+        ///
+        /// Append directly-connected P-Touch USB devices to the destination combo.
+        ///
+        void PrintView::loadPtouchDestinations( const QList<ptouch::UsbDeviceId>& devices )
+        {
+                if ( devices.isEmpty() )  return;
+
+                destinationCombo->blockSignals( true );
+
+                // Insert a labelled separator before P-Touch entries (if not already present)
+                // by searching for the "Print to file (PDF)" item and inserting above it.
+                int pdfIndex = destinationCombo->findText( tr("Print to file (PDF)") );
+                if ( pdfIndex < 0 )  pdfIndex = destinationCombo->count();
+
+                destinationCombo->insertSeparator( pdfIndex );
+                ++pdfIndex;
+
+                for ( const auto& id : devices )
+                {
+                        destinationCombo->insertItem(
+                            pdfIndex++,
+                            QIcon::fromTheme( "glabels-print" ),
+                            QString::fromStdString( id.displayName() ) );
+                }
 
                 destinationCombo->blockSignals( false );
         }

--- a/glabels/PrintView.hpp
+++ b/glabels/PrintView.hpp
@@ -24,6 +24,8 @@
 
 #include "ui_PrintView.h"
 
+#include "ptouch/DeviceMonitor.hpp"
+
 #include "model/Model.hpp"
 #include "model/PageRenderer.hpp"
 
@@ -58,6 +60,7 @@ namespace glabels
                 /////////////////////////////////
         private slots:
                 void onAvailablePrintersChanged( QStringList printers );
+                void onAvailablePtouchDevicesChanged( QList<ptouch::UsbDeviceId> devices );
                 void onModelChanged();
                 void updateView();
                 void onFormChanged();
@@ -70,8 +73,10 @@ namespace glabels
                 /////////////////////////////////
         private:
                 void loadDestinations( const QStringList& printers );
+                void loadPtouchDestinations( const QList<ptouch::UsbDeviceId>& devices );
                 QString defaultPdf();
                 void setDestination( const QString& printerName );
+                bool printToPtouch( const QString& deviceDisplayName );
 
 
                 /////////////////////////////////

--- a/glabels/ptouch/Device.cpp
+++ b/glabels/ptouch/Device.cpp
@@ -1,0 +1,295 @@
+//  ptouch/Device.cpp
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "Device.hpp"
+#include "Protocol.hpp"
+
+#include <QDebug>
+#include <QThread>
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+
+
+namespace glabels::ptouch
+{
+
+namespace
+{
+    // Status packet constants
+    constexpr int     kStatusPacketSize = 32;
+    constexpr uint8_t kStatusHead0      = 0x80;
+    constexpr uint8_t kStatusHead1      = 0x20;
+
+    // Byte offsets within the 32-byte status packet
+    constexpr int kOffError      = 8;   // 2 bytes, little-endian
+    constexpr int kOffMediaWidth = 10;
+    constexpr int kOffMediaType  = 11;
+    constexpr int kOffTapeColor  = 24;
+    constexpr int kOffTextColor  = 25;
+
+    /// Set bit @p pixel (0 = rightmost) in raster line @p line.
+    /// @p lineBytes is the number of bytes in the raster line (maxPixelWidth/8).
+    inline void rasterSetPixel(uint8_t* line, int lineBytes, int pixel) noexcept
+    {
+        if (pixel < 0 || pixel >= lineBytes * 8)  return;
+        // The bit layout matches the original libptouch convention:
+        // bit 0 of the last byte is the first physical pixel position.
+        line[(lineBytes - 1) - (pixel / 8)] |= static_cast<uint8_t>(1u << (pixel % 8));
+    }
+
+} // namespace
+
+
+// ─── Device ───────────────────────────────────────────────────────────────────
+
+Device::Device(std::unique_ptr<UsbTransport> transport,
+               const DeviceDescriptor*       descriptor,
+               UsbDeviceId                   id)
+    : mTransport(std::move(transport))
+    , mDescriptor(descriptor)
+    , mId(id)
+{}
+
+std::unique_ptr<Device> Device::open(UsbContext&        ctx,
+                                      const UsbDeviceId& id,
+                                      QString&           errorOut)
+{
+    const DeviceDescriptor* desc = findDevice(id.vid, id.pid);
+    if (!desc || !desc->isValid())
+    {
+        errorOut = QStringLiteral("Unknown P-Touch device (VID %1, PID %2)")
+                   .arg(id.vid, 4, 16, QLatin1Char('0'))
+                   .arg(id.pid, 4, 16, QLatin1Char('0'));
+        return nullptr;
+    }
+
+    if (desc->isPLite())
+    {
+        errorOut = QStringLiteral(
+            "%1 is in P-Lite mode, which is not supported for direct USB printing.\n"
+            "Turn off P-Lite mode (flip the switch from EL to E, or hold the PLite "
+            "button for ~2 seconds) and try again.").arg(QLatin1StringView(desc->name));
+        return nullptr;
+    }
+
+    if (desc->isUnsupported())
+    {
+        errorOut = QStringLiteral(
+            "%1 uses a raster format that is not yet supported.")
+                   .arg(QLatin1StringView(desc->name));
+        return nullptr;
+    }
+
+    std::string transportError;
+    auto transport = UsbTransport::open(ctx, id, transportError);
+    if (!transport)
+    {
+        errorOut = QString::fromStdString(transportError);
+        return nullptr;
+    }
+
+    // Use new directly since the constructor is private.
+    auto device = std::unique_ptr<Device>(
+        new Device(std::move(transport), desc, id));
+
+    // Hardware initialise: ESC @
+    QString initError;
+    if (!device->sendBytes(Protocol::init(), initError))
+    {
+        errorOut = QStringLiteral("Failed to initialise printer: ") + initError;
+        return nullptr;
+    }
+
+    return device;
+}
+
+QString Device::displayName() const
+{
+    return QString::fromStdString(mId.displayName());
+}
+
+bool Device::sendBytes(const QByteArray& data, QString& errorOut)
+{
+    std::string err;
+    bool ok = mTransport->write(
+        std::span<const uint8_t>(
+            reinterpret_cast<const uint8_t*>(data.constData()),
+            static_cast<size_t>(data.size())),
+        err);
+
+    if (!ok)  errorOut = QString::fromStdString(err);
+    return ok;
+}
+
+bool Device::queryStatus(DeviceStatus& statusOut, QString& errorOut)
+{
+    // Send the status request command
+    if (!sendBytes(Protocol::statusRequest(), errorOut))  return false;
+
+    // The printer takes a moment to respond; poll up to 10 times with 100 ms gaps
+    std::array<uint8_t, kStatusPacketSize> buf{};
+    int bytesRead = 0;
+
+    for (int attempt = 0; attempt < 10; ++attempt)
+    {
+        QThread::msleep(100);
+
+        std::string readErr;
+        if (!mTransport->read(std::span<uint8_t>(buf.data(), buf.size()),
+                               bytesRead, readErr))
+        {
+            errorOut = QStringLiteral("Status read failed: %1")
+                       .arg(QString::fromStdString(readErr));
+            return false;
+        }
+
+        if (bytesRead == kStatusPacketSize)  break;
+    }
+
+    if (bytesRead != kStatusPacketSize)
+    {
+        errorOut = QStringLiteral("Incomplete status packet (%1 of %2 bytes)")
+                   .arg(bytesRead).arg(kStatusPacketSize);
+        return false;
+    }
+
+    if (buf[0] != kStatusHead0 || buf[1] != kStatusHead1)
+    {
+        errorOut = QStringLiteral("Unexpected status packet header (0x%1 0x%2)")
+                   .arg(buf[0], 2, 16, QLatin1Char('0'))
+                   .arg(buf[1], 2, 16, QLatin1Char('0'));
+        return false;
+    }
+
+    statusOut.errorCode    = static_cast<uint16_t>(buf[kOffError] | (buf[kOffError + 1] << 8));
+    statusOut.mediaWidthMm = buf[kOffMediaWidth];
+    statusOut.mediaType    = buf[kOffMediaType];
+    statusOut.tapeColor    = buf[kOffTapeColor];
+    statusOut.textColor    = buf[kOffTextColor];
+
+    const TapeDescriptor* tape = findTape(statusOut.mediaWidthMm);
+    statusOut.tapePixelWidth = tape ? tape->printWidthPx : 0;
+
+    if (statusOut.tapePixelWidth == 0)
+    {
+        errorOut = QStringLiteral("Unknown tape width: %1 mm").arg(statusOut.mediaWidthMm);
+        return false;
+    }
+
+    qDebug() << "P-Touch status: tape" << statusOut.mediaWidthMm << "mm ="
+             << statusOut.tapePixelWidth << "px printable width"
+             << "| error code" << Qt::hex << statusOut.errorCode;
+
+    return true;
+}
+
+bool Device::printImage(const QImage& image, const DeviceStatus& status, QString& errorOut)
+{
+    if (!status.isValid())
+    {
+        errorOut = QStringLiteral("Invalid device status; call queryStatus() first");
+        return false;
+    }
+
+    const int imgW  = image.width();   // tape-feed direction (label length)
+    const int imgH  = image.height();  // across tape (label width)
+
+    if (imgH > mDescriptor->maxPixelWidth)
+    {
+        errorOut = QStringLiteral(
+            "Image height (%1 px) exceeds the print-head width (%2 px) on a %3")
+                   .arg(imgH)
+                   .arg(mDescriptor->maxPixelWidth)
+                   .arg(QLatin1StringView(mDescriptor->name));
+        return false;
+    }
+
+    const int lineBytes = mDescriptor->maxPixelWidth / 8;  // bytes per raster line (e.g. 16)
+
+    // Centre the image vertically within the print head's pixel range.
+    // The print head is always maxPixelWidth wide; the tape is narrower.
+    // offset is the bit index of the bottom-most pixel of the image within
+    // the raster line (bit 0 = physical edge the head scans from first).
+    const int offset = (mDescriptor->maxPixelWidth / 2) - (imgH / 2);
+
+    // ── Enter raster mode ───────────────────────────────────────────────────
+
+    if (mDescriptor->isPackBits())
+    {
+        if (!sendBytes(Protocol::enablePackBits(), errorOut))  return false;
+    }
+
+    const QByteArray modeCmd = mDescriptor->isP700Init()
+        ? Protocol::rasterModeP700()
+        : Protocol::rasterModeStandard();
+
+    if (!sendBytes(modeCmd, errorOut))  return false;
+
+    // ── Send raster data ────────────────────────────────────────────────────
+    //
+    // For each column k along the tape-feed axis:
+    //   • Build a raster line of lineBytes bytes (all zeros = blank column).
+    //   • For each row i across the tape, set the corresponding bit if the
+    //     image pixel at (k, i) is dark.
+    //   • Send the line (or an empty-line command if the line is all-blank).
+
+    // Work on a greyscale copy so pixel luminance is straightforward.
+    QImage mono = image.convertToFormat(QImage::Format_Grayscale8);
+
+    std::vector<uint8_t> rasterLine(static_cast<size_t>(lineBytes), 0);
+
+    for (int k = 0; k < imgW; ++k)
+    {
+        std::fill(rasterLine.begin(), rasterLine.end(), uint8_t(0));
+
+        bool anySet = false;
+        for (int i = 0; i < imgH; ++i)
+        {
+            // Pixel luminance: 0 = black (print), 255 = white (no print).
+            // qGray() on a Grayscale8 image returns the grey value directly.
+            //
+            // The print head scans from the bottom of the image upward, so
+            // image row (imgH-1) maps to raster bit offset+0, and image row 0
+            // maps to raster bit offset+(imgH-1).  This matches the libptouch /
+            // ptouch-print convention: gdImageGetPixel(im, k, imgH-1-i).
+            const int row = imgH - 1 - i;
+            if (qGray(mono.pixel(k, row)) < 128)
+            {
+                rasterSetPixel(rasterLine.data(), lineBytes, offset + i);
+                anySet = true;
+            }
+        }
+
+        QByteArray pkt;
+        if (!anySet)
+        {
+            pkt = Protocol::emptyRasterLine();
+        }
+        else
+        {
+            pkt = Protocol::rasterLine(
+                std::span<const uint8_t>(rasterLine.data(), rasterLine.size()),
+                mDescriptor->isPackBits());
+        }
+
+        if (!sendBytes(pkt, errorOut))  return false;
+    }
+
+    return true;
+}
+
+bool Device::eject(QString& errorOut)
+{
+    return sendBytes(Protocol::eject(), errorOut);
+}
+
+bool Device::formFeed(QString& errorOut)
+{
+    return sendBytes(Protocol::formFeed(), errorOut);
+}
+
+} // namespace glabels::ptouch

--- a/glabels/ptouch/Device.hpp
+++ b/glabels/ptouch/Device.hpp
@@ -1,0 +1,130 @@
+//  ptouch/Device.hpp
+//
+//  High-level abstraction of a connected Brother P-Touch label printer.
+//  Handles device initialisation, status querying, raster image printing,
+//  and tape ejection.
+//
+//  Usage:
+//
+//    UsbContext ctx;
+//    for (const auto& id : ctx.enumeratePtouchDevices()) {
+//        QString err;
+//        auto dev = Device::open(ctx, id, err);
+//        if (dev) {
+//            DeviceStatus st;
+//            if (dev->queryStatus(st, err)) {
+//                dev->printImage(image, st, err);
+//                dev->eject(err);
+//            }
+//        }
+//    }
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "DeviceDatabase.hpp"
+#include "UsbTransport.hpp"
+
+#include <QImage>
+#include <QString>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+
+namespace glabels::ptouch
+{
+
+// ─── DeviceStatus ─────────────────────────────────────────────────────────────
+
+/// Parsed contents of the 32-byte status packet returned by the printer.
+struct DeviceStatus
+{
+    uint16_t errorCode{};       ///< Raw error field from the status packet
+    uint8_t  mediaWidthMm{};    ///< Physical tape width in mm (e.g. 12)
+    uint8_t  mediaType{};       ///< Media type code
+    uint8_t  tapeColor{};       ///< Tape background colour code
+    uint8_t  textColor{};       ///< Text/ribbon colour code
+    uint16_t tapePixelWidth{};  ///< Printable pixel columns (looked up from kKnownTapes)
+
+    bool isValid() const noexcept { return tapePixelWidth > 0; }
+    bool hasError() const noexcept { return errorCode != 0; }
+};
+
+
+// ─── Device ───────────────────────────────────────────────────────────────────
+
+/// Represents a single open P-Touch device.  Not copyable; move is allowed
+/// only via the factory method (which returns a unique_ptr).
+class Device
+{
+public:
+    // ── Factory ──────────────────────────────────────────────────────────────
+
+    /// Open the device @p id within USB context @p ctx.
+    ///
+    /// On success returns a ready-to-use Device.  On failure returns nullptr
+    /// and fills @p errorOut with a human-readable message.
+    ///
+    /// The returned Device has already been hardware-initialised (ESC @).
+    static std::unique_ptr<Device> open(UsbContext&        ctx,
+                                         const UsbDeviceId& id,
+                                         QString&           errorOut);
+
+    ~Device() = default;
+
+    Device(const Device&)            = delete;
+    Device& operator=(const Device&) = delete;
+
+    // ── Accessors ────────────────────────────────────────────────────────────
+
+    const DeviceDescriptor& descriptor() const noexcept { return *mDescriptor; }
+    const UsbDeviceId&      deviceId()   const noexcept { return mId;          }
+
+    /// User-facing display name (e.g. "PT-P700 (USB bus 1, device 5)").
+    QString displayName() const;
+
+    // ── Operations ───────────────────────────────────────────────────────────
+
+    /// Query the printer for its current status (tape width, error state, etc.).
+    /// Must be called before printImage() to obtain a valid DeviceStatus.
+    bool queryStatus(DeviceStatus& statusOut, QString& errorOut);
+
+    /// Print one label image.
+    ///
+    /// @p image should be a monochrome or greyscale QImage.  Any format is
+    /// accepted; pixels with luminance < 128 are treated as "print" (dark).
+    ///
+    /// Image orientation: the image width is the label length in the tape-feed
+    /// direction; the image height is the print width across the tape.
+    ///
+    /// The image height must not exceed the device's maxPixelWidth (print-head
+    /// capacity).  Images narrower than the tape are centred automatically by
+    /// the hardware; images wider than the printable tape area but within
+    /// maxPixelWidth will print with content on the non-printable margins.
+    ///
+    /// @p status must have been obtained from a recent queryStatus() call.
+    bool printImage(const QImage& image, const DeviceStatus& status, QString& errorOut);
+
+    /// Advance and cut the tape (send 0x1A).
+    bool eject(QString& errorOut);
+
+    /// Advance the tape without cutting (send 0x0C).
+    bool formFeed(QString& errorOut);
+
+private:
+    Device(std::unique_ptr<UsbTransport> transport,
+           const DeviceDescriptor*       descriptor,
+           UsbDeviceId                   id);
+
+    bool sendBytes(const QByteArray& data, QString& errorOut);
+
+    std::unique_ptr<UsbTransport> mTransport;
+    const DeviceDescriptor*       mDescriptor;
+    UsbDeviceId                   mId;
+};
+
+} // namespace glabels::ptouch

--- a/glabels/ptouch/DeviceDatabase.hpp
+++ b/glabels/ptouch/DeviceDatabase.hpp
@@ -1,0 +1,131 @@
+//  ptouch/DeviceDatabase.hpp
+//
+//  Compile-time tables of known Brother P-Touch USB devices and tape widths.
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string_view>
+
+
+namespace glabels::ptouch
+{
+
+// ─── Device capability flags ──────────────────────────────────────────────────
+
+enum class DeviceFlags : uint32_t
+{
+    None           = 0,
+    UnsupRaster    = 1u << 0,  ///< Non-standard raster format; device is unsupported
+    RasterPackBits = 1u << 1,  ///< Raster rows must be sent PackBits-encoded
+    PLite          = 1u << 2,  ///< Device is in P-Lite mode; printing is unsupported
+    P700Init       = 1u << 3,  ///< Uses the PT-P700 raster-mode initialisation sequence
+};
+
+constexpr DeviceFlags operator|(DeviceFlags a, DeviceFlags b) noexcept
+{
+    return static_cast<DeviceFlags>( static_cast<uint32_t>(a) | static_cast<uint32_t>(b) );
+}
+
+/// Test whether @p set contains @p flag.
+constexpr bool hasFlag(DeviceFlags set, DeviceFlags flag) noexcept
+{
+    return (static_cast<uint32_t>(set) & static_cast<uint32_t>(flag)) != 0;
+}
+
+
+// ─── Device descriptor ────────────────────────────────────────────────────────
+
+/// Immutable compile-time descriptor for one supported P-Touch model.
+struct DeviceDescriptor
+{
+    uint16_t         vid;           ///< USB Vendor ID
+    uint16_t         pid;           ///< USB Product ID
+    std::string_view name;          ///< Human-readable model name
+    int              maxPixelWidth; ///< Print-head width in native-DPI pixels
+    int              dpi;           ///< Native print resolution (dots per inch)
+    DeviceFlags      flags;
+
+    constexpr bool isValid()        const noexcept { return vid != 0; }
+    constexpr bool isPLite()        const noexcept { return hasFlag(flags, DeviceFlags::PLite);          }
+    constexpr bool isPackBits()     const noexcept { return hasFlag(flags, DeviceFlags::RasterPackBits); }
+    constexpr bool isP700Init()     const noexcept { return hasFlag(flags, DeviceFlags::P700Init);       }
+    constexpr bool isUnsupported()  const noexcept { return hasFlag(flags, DeviceFlags::UnsupRaster);    }
+};
+
+
+// ─── Tape descriptor ──────────────────────────────────────────────────────────
+
+/// Maps a physical tape width (in mm, as reported by the printer status) to
+/// its printable pixel count and the non-printable side margins.
+struct TapeDescriptor
+{
+    uint8_t  widthMm;       ///< Physical tape width in millimetres
+    uint16_t printWidthPx;  ///< Printable pixel columns across the tape
+    double   sideMarginMm;  ///< Approximate non-printable margin on each lateral edge
+};
+
+
+// ─── Supported devices ────────────────────────────────────────────────────────
+
+inline constexpr std::array<DeviceDescriptor, 14> kKnownDevices {{
+    // vid     pid     name                          maxPx   dpi  flags
+    { 0x04f9, 0x2007, "PT-2420PC",                  128,   180,  DeviceFlags::RasterPackBits                         },
+    { 0x04f9, 0x202c, "PT-1230PC",                  128,   180,  DeviceFlags::None                                   },
+    { 0x04f9, 0x202d, "PT-2430PC",                  128,   180,  DeviceFlags::None                                   },
+    { 0x04f9, 0x2030, "PT-1230PC (PLite Mode)",     128,   180,  DeviceFlags::PLite                                  },
+    { 0x04f9, 0x2031, "PT-2430PC (PLite Mode)",     128,   180,  DeviceFlags::PLite                                  },
+    { 0x04f9, 0x2041, "PT-2730",                    128,   180,  DeviceFlags::None                                   },
+    { 0x04f9, 0x205f, "PT-E500",                    128,   180,  DeviceFlags::RasterPackBits                         },
+    { 0x04f9, 0x2061, "PT-P700",                    128,   180,  DeviceFlags::RasterPackBits | DeviceFlags::P700Init },
+    { 0x04f9, 0x2064, "PT-P700 (PLite Mode)",       128,   180,  DeviceFlags::PLite                                  },
+    { 0x04f9, 0x2062, "PT-P750W",                   128,   180,  DeviceFlags::RasterPackBits | DeviceFlags::P700Init },
+    { 0x04f9, 0x2065, "PT-P750W (PLite Mode)",      128,   180,  DeviceFlags::PLite                                  },
+    { 0x04f9, 0x2073, "PT-D450",                    128,   180,  DeviceFlags::RasterPackBits                         },
+    { 0x04f9, 0x2074, "PT-D600",                    128,   180,  DeviceFlags::RasterPackBits                         },
+    { 0,      0,      "",                           0,     0,    DeviceFlags::None                                   }, // sentinel
+}};
+
+
+// ─── Supported tape widths ────────────────────────────────────────────────────
+
+inline constexpr std::array<TapeDescriptor, 7> kKnownTapes {{
+    //  mm    px    margin
+    {  6,    32,   1.0 },
+    {  9,    52,   1.0 },
+    { 12,    76,   2.0 },
+    { 18,   120,   3.0 },
+    { 24,   128,   3.0 },
+    { 36,   192,   4.5 },
+    {  0,     0,   0.0 }, // sentinel
+}};
+
+
+// ─── Lookup helpers ───────────────────────────────────────────────────────────
+
+/// Find a device descriptor by VID/PID.  Returns nullptr if the device is unknown.
+inline constexpr const DeviceDescriptor* findDevice(uint16_t vid, uint16_t pid) noexcept
+{
+    for (const auto& d : kKnownDevices)
+    {
+        if (d.vid == vid && d.pid == pid)  return &d;
+    }
+    return nullptr;
+}
+
+/// Find a tape descriptor by physical width (mm, as reported in the status packet).
+/// Returns nullptr if the width is not in the table.
+inline constexpr const TapeDescriptor* findTape(uint8_t widthMm) noexcept
+{
+    for (const auto& t : kKnownTapes)
+    {
+        if (t.widthMm == widthMm)  return &t;
+    }
+    return nullptr;
+}
+
+} // namespace glabels::ptouch

--- a/glabels/ptouch/DeviceMonitor.cpp
+++ b/glabels/ptouch/DeviceMonitor.cpp
@@ -1,0 +1,127 @@
+//  ptouch/DeviceMonitor.cpp
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "DeviceMonitor.hpp"
+
+#include <QMutexLocker>
+#include <QtConcurrentRun>
+
+#include <algorithm>
+#include <chrono>
+
+
+namespace glabels::ptouch
+{
+
+std::unique_ptr<DeviceMonitor> DeviceMonitor::mInstance;
+
+DeviceMonitor::DeviceMonitor()
+{
+    using namespace std::chrono_literals;
+
+    // Initial synchronous enumeration so the list is populated immediately.
+    {
+        auto v = mUsbContext.enumeratePtouchDevices();
+        mCurrentDevices = QList<UsbDeviceId>(v.cbegin(), v.cend());
+    }
+
+    mTimer = std::make_unique<QTimer>(this);
+    connect(mTimer.get(), &QTimer::timeout, this, &DeviceMonitor::onTimerTimeout);
+    mTimer->start(std::chrono::milliseconds(5s).count());
+}
+
+DeviceMonitor* DeviceMonitor::instance()
+{
+    if (!mInstance)
+    {
+        mInstance.reset(new DeviceMonitor());
+    }
+    return mInstance.get();
+}
+
+QList<UsbDeviceId> DeviceMonitor::availableDevices() const
+{
+    QMutexLocker lock(&mDevicesMutex);
+    return mCurrentDevices;
+}
+
+QStringList DeviceMonitor::availableDeviceNames() const
+{
+    QMutexLocker lock(&mDevicesMutex);
+    QStringList names;
+    names.reserve(mCurrentDevices.size());
+    for (const auto& id : mCurrentDevices)
+    {
+        names.append(QString::fromStdString(id.displayName()));
+    }
+    return names;
+}
+
+std::optional<UsbDeviceId> DeviceMonitor::findByDisplayName(const QString& displayName) const
+{
+    QMutexLocker lock(&mDevicesMutex);
+    for (const auto& id : mCurrentDevices)
+    {
+        if (QString::fromStdString(id.displayName()) == displayName)
+        {
+            return id;
+        }
+    }
+    return std::nullopt;
+}
+
+void DeviceMonitor::onTimerTimeout()
+{
+    if (mPollFuture.isFinished())
+    {
+        mPollFuture = QtConcurrent::run(&DeviceMonitor::asyncPoll, this);
+    }
+}
+
+void DeviceMonitor::asyncPoll()
+{
+    auto discovered = mUsbContext.enumeratePtouchDevices();
+
+    QList<UsbDeviceId> newList(discovered.cbegin(), discovered.cend());
+
+    // Take a snapshot of the current list under the mutex so the comparison
+    // below is race-free (writes to mCurrentDevices also happen under the mutex).
+    QList<UsbDeviceId> oldList;
+    {
+        QMutexLocker lock(&mDevicesMutex);
+        oldList = mCurrentDevices;
+    }
+
+    // Compare by bus+address+vid+pid
+    auto same = [](const UsbDeviceId& a, const UsbDeviceId& b) {
+        return a.vid == b.vid && a.pid == b.pid
+            && a.busNumber == b.busNumber
+            && a.deviceAddress == b.deviceAddress;
+    };
+
+    bool changed = (newList.size() != oldList.size());
+    if (!changed)
+    {
+        for (int i = 0; i < newList.size(); ++i)
+        {
+            if (!same(newList[i], oldList[i]))
+            {
+                changed = true;
+                break;
+            }
+        }
+    }
+
+    if (changed)
+    {
+        {
+            QMutexLocker lock(&mDevicesMutex);
+            mCurrentDevices = newList;
+        }
+        emit availableDevicesChanged(newList);
+    }
+}
+
+} // namespace glabels::ptouch

--- a/glabels/ptouch/DeviceMonitor.hpp
+++ b/glabels/ptouch/DeviceMonitor.hpp
@@ -1,0 +1,90 @@
+//  ptouch/DeviceMonitor.hpp
+//
+//  Singleton QObject that periodically enumerates attached P-Touch USB devices
+//  and emits availableDevicesChanged() when the set changes.
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "UsbTransport.hpp"
+
+#include <QFuture>
+#include <QList>
+#include <QMutex>
+#include <QObject>
+#include <QTimer>
+
+#include <memory>
+
+
+namespace glabels::ptouch
+{
+
+class DeviceMonitor : public QObject
+{
+    Q_OBJECT
+
+    /////////////////////////////////
+    // Life Cycle
+    /////////////////////////////////
+private:
+    DeviceMonitor();
+
+public:
+    static DeviceMonitor* instance();
+
+
+    /////////////////////////////////
+    // Public methods
+    /////////////////////////////////
+public:
+    /// Return the most recently enumerated list of connected P-Touch devices.
+    QList<UsbDeviceId> availableDevices() const;
+
+    /// Display names for each available device (for combo-boxes).
+    QStringList availableDeviceNames() const;
+
+    /// Find the UsbDeviceId matching @p displayName, if present.
+    std::optional<UsbDeviceId> findByDisplayName(const QString& displayName) const;
+
+    /// Return the shared UsbContext (valid for the lifetime of this singleton).
+    UsbContext& usbContext() { return mUsbContext; }
+
+
+    /////////////////////////////////
+    // Signals
+    /////////////////////////////////
+signals:
+    void availableDevicesChanged(QList<UsbDeviceId> devices);
+
+
+    /////////////////////////////////
+    // Slots
+    /////////////////////////////////
+private slots:
+    void onTimerTimeout();
+
+
+    /////////////////////////////////
+    // Private methods
+    /////////////////////////////////
+private:
+    void asyncPoll();
+
+
+    /////////////////////////////////
+    // Private data
+    /////////////////////////////////
+private:
+    static std::unique_ptr<DeviceMonitor> mInstance;
+
+    UsbContext              mUsbContext;
+    QList<UsbDeviceId>      mCurrentDevices;
+    mutable QMutex          mDevicesMutex;
+    std::unique_ptr<QTimer> mTimer;
+    QFuture<void>           mPollFuture;
+};
+
+} // namespace glabels::ptouch

--- a/glabels/ptouch/Printer.cpp
+++ b/glabels/ptouch/Printer.cpp
@@ -1,0 +1,74 @@
+//  ptouch/Printer.cpp
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "Printer.hpp"
+
+#include "model/PageRenderer.hpp"
+
+#include <QImage>
+
+
+namespace glabels::ptouch
+{
+
+Printer::Printer(Device& device, const DeviceStatus& status, QObject* parent)
+    : QObject(parent)
+    , mDevice(device)
+    , mStatus(status)
+{}
+
+int Printer::dpi()            const noexcept { return mDevice.descriptor().dpi;           }
+int Printer::maxPixelWidth()  const noexcept { return mDevice.descriptor().maxPixelWidth; }
+int Printer::tapePixelWidth() const noexcept { return mStatus.tapePixelWidth;             }
+
+bool Printer::print(const model::PageRenderer& renderer)
+{
+    mLastError.clear();
+
+    int labelCount = 0;
+    int totalLabels = renderer.nItems();
+
+    bool aborted = false;
+
+    renderer.enumerateLabels(static_cast<double>(dpi()),
+        [&](const QImage& labelImage) -> bool
+        {
+            if (labelImage.height() > maxPixelWidth())
+            {
+                mLastError = QStringLiteral(
+                    "Label width (%1 px at %2 DPI) exceeds the print head capacity "
+                    "(%3 px).  Please use a narrower template.")
+                    .arg(labelImage.height())
+                    .arg(dpi())
+                    .arg(maxPixelWidth());
+                aborted = true;
+                return false;   // stop enumeration
+            }
+
+            if (!mDevice.printImage(labelImage, mStatus, mLastError))
+            {
+                aborted = true;
+                return false;
+            }
+
+            ++labelCount;
+            emit progressChanged(labelCount, totalLabels);
+            return true;    // continue to next label
+        });
+
+    if (!aborted)
+    {
+        if (!mDevice.eject(mLastError))
+        {
+            emit finished();
+            return false;
+        }
+    }
+
+    emit finished();
+    return !aborted;
+}
+
+} // namespace glabels::ptouch

--- a/glabels/ptouch/Printer.hpp
+++ b/glabels/ptouch/Printer.hpp
@@ -1,0 +1,83 @@
+//  ptouch/Printer.hpp
+//
+//  High-level label printer: drives a Device from a model::PageRenderer.
+//
+//  Typical use (from PrintView):
+//
+//    ptouch::Printer printer(*device, deviceStatus);
+//    printer.print(renderer);
+//    if (printer.lastError().isEmpty()) { ... }
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "Device.hpp"
+
+#include <QObject>
+#include <QString>
+
+
+namespace glabels::model { class PageRenderer; }
+
+
+namespace glabels::ptouch
+{
+
+/// Bridges a model::PageRenderer to a P-Touch Device.
+///
+/// Iterates over every label item produced by the renderer, renders each one
+/// to a QImage at the device's native DPI, and submits it to the device via
+/// Device::printImage().  After the last label the tape is ejected and cut.
+///
+/// All operations are synchronous and happen on the calling thread.
+class Printer : public QObject
+{
+    Q_OBJECT
+
+public:
+    /// Construct a Printer for @p device.  @p status must be a freshly
+    /// obtained DeviceStatus (call Device::queryStatus() immediately before).
+    explicit Printer(Device& device, const DeviceStatus& status,
+                     QObject* parent = nullptr);
+
+    // ── Print ────────────────────────────────────────────────────────────────
+
+    /// Render and print every label item from @p renderer to the device.
+    /// Returns true on success.  On failure lastError() contains a description.
+    ///
+    /// Emits progressChanged() for each label submitted and finished() at the end.
+    bool print(const model::PageRenderer& renderer);
+
+    // ── Result ───────────────────────────────────────────────────────────────
+
+    /// The last error message, or an empty string if the last print succeeded.
+    QString lastError() const { return mLastError; }
+
+    // ── Device info ──────────────────────────────────────────────────────────
+
+    /// Native device DPI (used to scale labels to pixels).
+    int dpi() const noexcept;
+
+    /// Maximum pixel width of the print head.
+    int maxPixelWidth() const noexcept;
+
+    /// Printable pixel width of the loaded tape.
+    int tapePixelWidth() const noexcept;
+
+signals:
+    /// Emitted after each label image is sent to the device.
+    /// @p completed is 1-based; @p total is the total label count.
+    void progressChanged(int completed, int total);
+
+    /// Emitted when all labels have been sent (whether or not there was an error).
+    void finished();
+
+private:
+    Device&      mDevice;
+    DeviceStatus mStatus;
+    QString      mLastError;
+};
+
+} // namespace glabels::ptouch

--- a/glabels/ptouch/Protocol.hpp
+++ b/glabels/ptouch/Protocol.hpp
@@ -1,0 +1,126 @@
+//  ptouch/Protocol.hpp
+//
+//  Stateless functions that encode Brother P-Touch raster protocol commands
+//  into QByteArray packets ready to be sent over USB.
+//
+//  The P-Touch raster protocol uses these key commands:
+//    ESC @           – Reset / initialise printer
+//    ESC i S         – Request 32-byte status response
+//    M 0x02          – Enable PackBits compression mode
+//    ESC i R 0x01    – Enter raster graphics mode  (most models)
+//    ESC i a 0x01    – Switch to raster mode        (PT-P700 / PT-P750W)
+//    0x47 <len> 0x00 <data>            – Raw raster line
+//    0x47 <len+1> 0x00 <n-1> <data>   – PackBits-wrapped raster line
+//    0x5A                              – Empty raster line (skip column)
+//    0x0C                              – Form-feed (advance + no cut)
+//    0x1A                              – Eject (advance + cut)
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QByteArray>
+
+#include <cstdint>
+#include <span>
+
+
+namespace glabels::ptouch::Protocol
+{
+
+// ─── Control commands ─────────────────────────────────────────────────────────
+
+/// ESC @ – reset the printer to its power-on state.
+inline QByteArray init()
+{
+    return QByteArray("\x1b\x40", 2);
+}
+
+/// ESC i S – request a 32-byte status packet from the printer.
+inline QByteArray statusRequest()
+{
+    return QByteArray("\x1b\x69\x53", 3);
+}
+
+/// M 0x02 – enable PackBits (TIFF) compression for subsequent raster lines.
+inline QByteArray enablePackBits()
+{
+    return QByteArray("\x4d\x02", 2);
+}
+
+/// ESC i R 0x01 – enter raster graphics transfer mode (standard models).
+inline QByteArray rasterModeStandard()
+{
+    return QByteArray("\x1b\x69\x52\x01", 4);
+}
+
+/// ESC i a 0x01 – enter raster graphics mode (PT-P700 / PT-P750W variant).
+inline QByteArray rasterModeP700()
+{
+    return QByteArray("\x1b\x69\x61\x01", 4);
+}
+
+/// 0x5A – send a blank raster line (advance the tape by one dot column without printing).
+inline QByteArray emptyRasterLine()
+{
+    return QByteArray(1, '\x5a');
+}
+
+/// 0x0C – form-feed: advance the tape to the cut position without cutting.
+inline QByteArray formFeed()
+{
+    return QByteArray(1, '\x0c');
+}
+
+/// 0x1A – eject: advance the tape and cut it.
+inline QByteArray eject()
+{
+    return QByteArray(1, '\x1a');
+}
+
+
+// ─── Raster line encoding ─────────────────────────────────────────────────────
+
+/// Build a single raster-transfer packet from @p rowData.
+///
+/// @p rowData must be exactly (device.maxPixelWidth / 8) bytes.
+///
+/// When @p packBits is false (older models), the packet is:
+///   0x47  <len>  0x00  <data...>
+///
+/// When @p packBits is true (FLAG_RASTER_PACKBITS models), the row is wrapped
+/// as a single uncompressed PackBits literal run:
+///   0x47  <len+1>  0x00  <len-1>  <data...>
+///
+/// Both encodings result in one dot column being printed.
+inline QByteArray rasterLine(std::span<const uint8_t> rowData, bool packBits)
+{
+    const auto len = static_cast<uint8_t>(rowData.size());
+
+    QByteArray pkt;
+
+    if (packBits)
+    {
+        // PackBits literal run header:
+        //   count byte = 0x00 means "copy next N+1 bytes verbatim", so N = len-1
+        pkt.reserve(4 + len);
+        pkt.append('\x47');
+        pkt.append(static_cast<char>(len + 1));   // payload size (run-header + data)
+        pkt.append('\x00');                        // PackBits: literal run
+        pkt.append(static_cast<char>(len - 1));   // N (N+1 bytes follow)
+    }
+    else
+    {
+        pkt.reserve(3 + len);
+        pkt.append('\x47');
+        pkt.append(static_cast<char>(len));        // raw payload size
+        pkt.append('\x00');                        // padding byte
+    }
+
+    pkt.append(reinterpret_cast<const char*>(rowData.data()),
+               static_cast<qsizetype>(rowData.size()));
+    return pkt;
+}
+
+} // namespace glabels::ptouch::Protocol

--- a/glabels/ptouch/UsbTransport.cpp
+++ b/glabels/ptouch/UsbTransport.cpp
@@ -1,0 +1,286 @@
+//  ptouch/UsbTransport.cpp
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "UsbTransport.hpp"
+
+#ifdef HAVE_LIBUSB
+#  include <libusb-1.0/libusb.h>
+#endif
+
+#include <cstring>
+
+
+namespace glabels::ptouch
+{
+
+namespace
+{
+    constexpr uint8_t kEndpointOut = 0x02;
+    constexpr uint8_t kEndpointIn  = 0x81;
+    constexpr int     kInterface   = 0;
+    constexpr int     kTimeoutMs   = 5000;
+
+#ifdef HAVE_LIBUSB
+    // Convenience cast helpers to reduce visual noise.
+    inline libusb_context*       asCtx(void* p)    { return static_cast<libusb_context*>(p);       }
+    inline libusb_device_handle* asHnd(void* p)    { return static_cast<libusb_device_handle*>(p); }
+#endif
+}
+
+
+// ─── UsbDeviceId ─────────────────────────────────────────────────────────────
+
+std::string UsbDeviceId::displayName() const
+{
+    const auto* desc = findDevice(vid, pid);
+    std::string name = desc ? std::string(desc->name) : "Unknown P-Touch";
+    return name
+           + " (USB bus "    + std::to_string(busNumber)
+           + ", device "     + std::to_string(deviceAddress) + ")";
+}
+
+
+// ─── UsbContext ───────────────────────────────────────────────────────────────
+
+UsbContext::UsbContext()
+{
+#ifdef HAVE_LIBUSB
+    libusb_context* ctx = nullptr;
+    int rc = libusb_init(&ctx);
+    if (rc < 0)
+    {
+        mError = std::string("libusb_init: ") + libusb_error_name(rc);
+        return;
+    }
+    mCtx = ctx;
+#else
+    mError = "libusb-1.0 support was not compiled in";
+#endif
+}
+
+UsbContext::~UsbContext()
+{
+#ifdef HAVE_LIBUSB
+    if (mCtx)
+    {
+        libusb_exit(asCtx(mCtx));
+    }
+#endif
+}
+
+std::vector<UsbDeviceId> UsbContext::enumeratePtouchDevices() const
+{
+    std::vector<UsbDeviceId> result;
+
+#ifdef HAVE_LIBUSB
+    if (!mCtx)  return result;
+
+    libusb_device** devList  = nullptr;
+    ssize_t         devCount = libusb_get_device_list(asCtx(mCtx), &devList);
+
+    if (devCount < 0)  return result;
+
+    for (ssize_t i = 0; i < devCount; ++i)
+    {
+        libusb_device_descriptor desc{};
+        if (libusb_get_device_descriptor(devList[i], &desc) < 0)  continue;
+
+        if (findDevice(desc.idVendor, desc.idProduct) != nullptr)
+        {
+            result.push_back({
+                desc.idVendor,
+                desc.idProduct,
+                libusb_get_bus_number(devList[i]),
+                libusb_get_device_address(devList[i])
+            });
+        }
+    }
+
+    libusb_free_device_list(devList, 1);
+#endif
+
+    return result;
+}
+
+
+// ─── UsbTransport ─────────────────────────────────────────────────────────────
+
+UsbTransport::UsbTransport(void* handle, bool driverWasActive)
+    : mHandle(handle), mDriverWasActive(driverWasActive)
+{}
+
+UsbTransport::~UsbTransport()
+{
+#ifdef HAVE_LIBUSB
+    if (!mHandle)  return;
+
+    libusb_release_interface(asHnd(mHandle), kInterface);
+
+    if (mDriverWasActive)
+    {
+        libusb_attach_kernel_driver(asHnd(mHandle), kInterface);
+    }
+
+    libusb_close(asHnd(mHandle));
+#endif
+}
+
+std::unique_ptr<UsbTransport> UsbTransport::open(UsbContext&        ctx,
+                                                   const UsbDeviceId& id,
+                                                   std::string&       errorOut)
+{
+#ifdef HAVE_LIBUSB
+    if (!ctx.isValid())
+    {
+        errorOut = ctx.error();
+        return nullptr;
+    }
+
+    libusb_device** devList  = nullptr;
+    ssize_t         devCount = libusb_get_device_list(asCtx(ctx.rawContext()), &devList);
+
+    if (devCount < 0)
+    {
+        errorOut = std::string("libusb_get_device_list: ")
+                   + libusb_error_name(static_cast<int>(devCount));
+        return nullptr;
+    }
+
+    libusb_device* target = nullptr;
+    for (ssize_t i = 0; i < devCount && !target; ++i)
+    {
+        if (libusb_get_bus_number(devList[i])     == id.busNumber     &&
+            libusb_get_device_address(devList[i]) == id.deviceAddress)
+        {
+            target = devList[i];
+        }
+    }
+
+    if (!target)
+    {
+        libusb_free_device_list(devList, 1);
+        errorOut = "P-Touch device is no longer connected";
+        return nullptr;
+    }
+
+    libusb_device_handle* handle = nullptr;
+    int rc = libusb_open(target, &handle);
+    libusb_free_device_list(devList, 1);
+
+    if (rc < 0)
+    {
+        errorOut = std::string("libusb_open: ") + libusb_error_name(rc);
+        return nullptr;
+    }
+
+    // Detach the kernel driver (e.g. usblp) if it has claimed the interface.
+    bool driverWasActive = false;
+    if (libusb_kernel_driver_active(handle, kInterface) == 1)
+    {
+        driverWasActive = true;
+        rc = libusb_detach_kernel_driver(handle, kInterface);
+        if (rc < 0)
+        {
+            libusb_close(handle);
+            errorOut = std::string("libusb_detach_kernel_driver: ") + libusb_error_name(rc);
+            return nullptr;
+        }
+    }
+
+    rc = libusb_claim_interface(handle, kInterface);
+    if (rc < 0)
+    {
+        if (driverWasActive)  libusb_attach_kernel_driver(handle, kInterface);
+        libusb_close(handle);
+        errorOut = std::string("libusb_claim_interface: ") + libusb_error_name(rc);
+        return nullptr;
+    }
+
+    // Use `new` directly because the constructor is private.
+    return std::unique_ptr<UsbTransport>(new UsbTransport(handle, driverWasActive));
+
+#else
+    (void)ctx;  (void)id;
+    errorOut = "libusb-1.0 support was not compiled in";
+    return nullptr;
+#endif
+}
+
+bool UsbTransport::write(std::span<const uint8_t> data, std::string& errorOut)
+{
+#ifdef HAVE_LIBUSB
+    if (!mHandle)
+    {
+        errorOut = "USB device not open";
+        return false;
+    }
+
+    // libusb_bulk_transfer takes a non-const pointer but does not modify the data.
+    auto* buf = const_cast<uint8_t*>(data.data());
+    int   transferred = 0;
+
+    int rc = libusb_bulk_transfer(
+        asHnd(mHandle),
+        kEndpointOut,
+        buf,
+        static_cast<int>(data.size()),
+        &transferred,
+        kTimeoutMs);
+
+    if (rc < 0)
+    {
+        errorOut = std::string("USB write: ") + libusb_error_name(rc);
+        return false;
+    }
+    if (transferred != static_cast<int>(data.size()))
+    {
+        errorOut = "USB write: short write ("
+                   + std::to_string(transferred) + " of "
+                   + std::to_string(data.size()) + " bytes)";
+        return false;
+    }
+    return true;
+
+#else
+    (void)data;
+    errorOut = "libusb-1.0 support was not compiled in";
+    return false;
+#endif
+}
+
+bool UsbTransport::read(std::span<uint8_t> buffer, int& bytesRead, std::string& errorOut)
+{
+#ifdef HAVE_LIBUSB
+    if (!mHandle)
+    {
+        errorOut = "USB device not open";
+        bytesRead = 0;
+        return false;
+    }
+
+    bytesRead = 0;
+    int rc = libusb_bulk_transfer(
+        asHnd(mHandle),
+        kEndpointIn,
+        buffer.data(),
+        static_cast<int>(buffer.size()),
+        &bytesRead,
+        kTimeoutMs);
+
+    if (rc < 0)
+    {
+        errorOut = std::string("USB read: ") + libusb_error_name(rc);
+        return false;
+    }
+    return true;
+
+#else
+    (void)buffer;  (void)bytesRead;
+    errorOut = "libusb-1.0 support was not compiled in";
+    return false;
+#endif
+}
+
+} // namespace glabels::ptouch

--- a/glabels/ptouch/UsbTransport.hpp
+++ b/glabels/ptouch/UsbTransport.hpp
@@ -1,0 +1,113 @@
+//  ptouch/UsbTransport.hpp
+//
+//  RAII wrappers around libusb-1.0 for P-Touch USB bulk-transfer I/O.
+//
+//  Neither header includes libusb directly; all libusb types are kept behind
+//  void* handles so that downstream code can include this header without
+//  depending on the libusb headers.  The actual libusb calls live in
+//  UsbTransport.cpp, guarded by #ifdef HAVE_LIBUSB.
+//
+//  Copyright (C) 2026  gLabels-qt contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "DeviceDatabase.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+
+namespace glabels::ptouch
+{
+
+// ─── Discovered device identifier ─────────────────────────────────────────────
+
+/// Identifies a physical USB device currently attached to the host.
+/// Bus-number + device-address uniquely identify the device for opening.
+struct UsbDeviceId
+{
+    uint16_t vid;
+    uint16_t pid;
+    uint8_t  busNumber;
+    uint8_t  deviceAddress;
+
+    /// Display string suitable for combo-boxes / log messages.
+    std::string displayName() const;
+};
+
+
+// ─── UsbContext ───────────────────────────────────────────────────────────────
+
+/// RAII owner of a libusb session.  Construct once; pass by reference.
+///
+/// Calls libusb_init() in the constructor and libusb_exit() in the destructor.
+/// If initialisation fails, isValid() returns false and error() explains why.
+class UsbContext
+{
+public:
+    UsbContext();
+    ~UsbContext();
+
+    UsbContext(const UsbContext&)            = delete;
+    UsbContext& operator=(const UsbContext&) = delete;
+
+    bool               isValid() const noexcept { return mCtx != nullptr; }
+    const std::string& error()   const noexcept { return mError; }
+
+    /// Raw libusb_context* for use by UsbTransport (same translation unit).
+    void* rawContext() const noexcept { return mCtx; }
+
+    /// Enumerate all currently connected P-Touch devices that appear in
+    /// kKnownDevices.  Returns an empty list if libusb is unavailable or
+    /// if no matching device is found.
+    std::vector<UsbDeviceId> enumeratePtouchDevices() const;
+
+private:
+    void* mCtx{ nullptr };  // libusb_context*
+    std::string mError;
+};
+
+
+// ─── UsbTransport ─────────────────────────────────────────────────────────────
+
+/// Open, RAII-managed connection to a single USB device.
+///
+/// On construction the kernel driver is detached if active (and re-attached on
+/// destruction), and interface 0 is claimed (and released on destruction).
+///
+/// All I/O is synchronous bulk transfer.
+class UsbTransport
+{
+public:
+    /// Open the device identified by @p id within @p ctx.
+    /// Returns nullptr on failure; @p errorOut receives a description.
+    static std::unique_ptr<UsbTransport> open(UsbContext&        ctx,
+                                               const UsbDeviceId& id,
+                                               std::string&       errorOut);
+
+    ~UsbTransport();
+
+    UsbTransport(const UsbTransport&)            = delete;
+    UsbTransport& operator=(const UsbTransport&) = delete;
+
+    /// Bulk-write @p data to endpoint 0x02.
+    /// Returns false and fills @p errorOut on failure.
+    bool write(std::span<const uint8_t> data, std::string& errorOut);
+
+    /// Bulk-read up to buffer.size() bytes from endpoint 0x81.
+    /// @p bytesRead is set to the actual byte count on success.
+    /// Returns false and fills @p errorOut on failure.
+    bool read(std::span<uint8_t> buffer, int& bytesRead, std::string& errorOut);
+
+private:
+    explicit UsbTransport(void* handle, bool driverWasActive);
+
+    void* mHandle;           // libusb_device_handle*
+    bool  mDriverWasActive;
+};
+
+} // namespace glabels::ptouch

--- a/model/PageRenderer.cpp
+++ b/model/PageRenderer.cpp
@@ -28,6 +28,8 @@
 #include "merge/Record.hpp"
 
 #include <QDebug>
+#include <QImage>
+#include <QPainter>
 
 
 //
@@ -590,6 +592,123 @@ namespace glabels::model
                 mModel->draw( painter, false, record, variables );
 
                 painter->restore();
+        }
+
+
+        ///
+        /// Enumerate all label items as rendered QImages (for tape/direct printers).
+        ///
+        void PageRenderer::enumerateLabels( double                                    dpi,
+                                            const std::function<bool(const QImage&)>& callback ) const
+        {
+                if ( !mModel )  return;
+
+                const double scale = dpi / 72.0;            // PostScript points → device pixels
+                const int    wPx   = qRound( mModel->w().pt() * scale );
+                const int    hPx   = qRound( mModel->h().pt() * scale );
+
+                // Render one label into a QImage and invoke the callback.
+                // Returns false if the callback requests abort.
+                // For P-Touch tape printing the image must be oriented as:
+                //   image width  = tape feed direction  (the LONG label dimension)
+                //   image height = tape print direction (the SHORT label dimension)
+                //
+                // "Vertical orientation" labels (portrait, h > w):
+                //   Long dim = h → image width,  Short dim = w → image height
+                //   Requires axis-swap: model-x → image-y, model-y → image-x
+                //
+                // "Horizontal orientation" labels (landscape, w >= h):
+                //   Long dim = w → image width,  Short dim = h → image height
+                //   Plain scale: no axis swap needed
+                //
+                // QTransform(m11, m12, m21, m22, dx, dy):
+                //   x' = m11*x + m21*y + dx
+                //   y' = m12*x + m22*y + dy
+
+                const bool swapAxes = (hPx > wPx);
+                const int  imgW     = swapAxes ? hPx : wPx;
+                const int  imgH     = swapAxes ? wPx : hPx;
+
+                QTransform baseTransform;
+                if ( swapAxes )
+                {
+                        // Axis-swap (vertical/portrait label)
+                        // Normal:  model-x→img-y, model-y→img-x
+                        // Reverse: mirror tape-feed (model y-axis)
+                        baseTransform = mPrintReverse
+                                ? QTransform( 0.0, scale, -scale, 0.0, static_cast<double>(hPx), 0.0 )
+                                : QTransform( 0.0, scale,  scale, 0.0, 0.0,                      0.0 );
+                }
+                else
+                {
+                        // Plain scale (horizontal/landscape label)
+                        // Normal:  model-x→img-x, model-y→img-y
+                        // Reverse: mirror tape-feed (model x-axis)
+                        baseTransform = mPrintReverse
+                                ? QTransform( -scale, 0.0, 0.0, scale, static_cast<double>(wPx), 0.0 )
+                                : QTransform(  scale, 0.0, 0.0, scale, 0.0,                      0.0 );
+                }
+
+                auto renderOne = [&]( const merge::Record& record,
+                                      Variables&           variables ) -> bool
+                {
+                        QImage img( imgW, imgH, QImage::Format_RGB32 );
+                        img.fill( Qt::white );
+
+                        QPainter painter( &img );
+                        painter.setTransform( baseTransform );
+
+                        mModel->draw( &painter, false, record, variables );
+                        painter.end();
+
+                        return callback( img );
+                };
+
+                if ( !mIsMerge )
+                {
+                        // ── Simple (no merge) ──────────────────────────────────────────
+                        Variables variables( mModel->constVariables() );
+
+                        for ( int i = 0; i < mNCopies; ++i )
+                        {
+                                if ( !renderOne( merge::NullRecord(), variables ) )  return;
+                                variables.incrementVariablesOnItem();
+                                variables.incrementVariablesOnCopy();
+                        }
+                }
+                else if ( mIsCollated )
+                {
+                        // ── Collated merge: all records × copies ───────────────────────
+                        auto records = mMerge->selectedRecords();
+                        Variables variables( mModel->constVariables() );
+
+                        for ( int copy = 0; copy < mNCopies; ++copy )
+                        {
+                                for ( const auto& record : records )
+                                {
+                                        if ( !renderOne( record, variables ) )  return;
+                                        variables.incrementVariablesOnItem();
+                                }
+                                variables.incrementVariablesOnCopy();
+                        }
+                }
+                else
+                {
+                        // ── Un-collated merge: each record × copies ────────────────────
+                        auto records = mMerge->selectedRecords();
+                        Variables variables( mModel->constVariables() );
+
+                        for ( const auto& record : records )
+                        {
+                                for ( int copy = 0; copy < mNCopies; ++copy )
+                                {
+                                        if ( !renderOne( record, variables ) )  return;
+                                        variables.incrementVariablesOnItem();
+                                        variables.incrementVariablesOnCopy();
+                                }
+                                variables.resetOnCopyVariables();
+                        }
+                }
         }
 
 }

--- a/model/PageRenderer.hpp
+++ b/model/PageRenderer.hpp
@@ -28,8 +28,10 @@
 #include "merge/Merge.hpp"
 #include "merge/Record.hpp"
 
+#include <functional>
 #include <QPainter>
 #include <QPrinter>
+#include <QImage>
 #include <QRect>
 #include <QVector>
 
@@ -75,6 +77,17 @@ namespace glabels::model
                 void print( QPrinter* printer ) const;
                 void printPage( QPainter* painter ) const;
                 void printPage( QPainter* painter, int iPage ) const;
+
+                /// Enumerate every label item in this print job, rendering each one to
+                /// a QImage at @p dpi resolution and invoking @p callback with it.
+                ///
+                /// Image orientation for tape printers:
+                ///   width  = tape feed direction (the LONG / label-length dimension)
+                ///   height = across the tape     (the SHORT / tape-width dimension)
+                ///
+                /// The callback should return @c true to continue or @c false to abort.
+                void enumerateLabels( double dpi,
+                                      const std::function<bool(const QImage&)>& callback ) const;
 
 
                 /////////////////////////////////

--- a/templates/brother-other-templates.xml
+++ b/templates/brother-other-templates.xml
@@ -198,7 +198,7 @@
     <Meta category="label"/>
     <Meta category="mail"/>
     <Meta category="filing"/>
-    <Label-continuous id="0" width="12mm" min_height="25mm" max_height="1000mm" default_height="100mm" >
+    <Label-continuous id="0" width="12mm" min_height="10mm" max_height="1000mm" default_height="100mm" >
       <Markup-margin x_size="1.5mm" y_size="3.0mm" />
       <Layout nx="1" ny="1" x0="0" y0="0" dx="0" dy="0"/>
     </Label-continuous>

--- a/translations/glabels_C.ts
+++ b/translations/glabels_C.ts
@@ -2168,6 +2168,40 @@
         <source>Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>P-Touch Print Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Device &quot;%1&quot; is no longer connected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open device:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read printer status:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>P-Touch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printer reports an error (code 0x%1).  Check that tape is loaded and the cover is closed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Printing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sending %1 label(s) to %2…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>glabels::PropertiesView</name>


### PR DESCRIPTION

* Adds support for printing directly to Brother P-Touch USB devices 
  * Devices appear directly in the printer selection menu
  * Hot-plugging is supported; even from within the print tab
* Shorten the minimum label length for Brother DK-22214 12mm
  *  Would benefit from completing both of:
      * https://github.com/j-evins/glabels-qt/pull/183
      * https://github.com/j-evins/glabels-qt/pull/233
  * Would benefit from completing https://github.com/j-evins/glabels-qt/issues/115 
* Could potentially auto-detect loaded label width and update template automagically (`statusOut.mediaWidthMm`)

These devices do not have drivers available for Linux; however, a direct USB library exists, which I used as the reference for this implementation: https://github.com/torbenwendt/ptouch-print

Should support the following models, but I only tested with PT-1230PC.
- PT-2420PC
- PT-1230PC
- PT-2430PC
- PT-2730
- PT-2730
- PT-P700 (closes: https://github.com/j-evins/glabels-qt/issues/34 )
- PT-D450

I used GitHub CoPilot with Claude Sonnet 4.6 to create this change.

Example:
<img width="1154" height="932" alt="image" src="https://github.com/user-attachments/assets/75197495-e69a-42b5-a1e7-6362fff57012" />

![PXL_20260704_210034412.jpg](https://github.com/user-attachments/assets/87917861-cd2a-42dd-8cf4-0110abaa450a)

